### PR TITLE
Update mLab URL

### DIFF
--- a/3. Installing and Updating/1. Minimum Requirements.md
+++ b/3. Installing and Updating/1. Minimum Requirements.md
@@ -40,4 +40,4 @@ Raspberry Pi 3 or Pi 2 ($35 all-in-one system)
 4 Cores 1 GB memory 
 32GB SD Card ($15)
 
-The above minimal configuration can accomodate a small office or group of up to 50 users and up to 25 concurrently active and moderate level of mixed uploads, sharing, and bot activites. This is based on a managed MongoDB service (such as [mlab.com](mlab.com)). Running mongo local to a Pi is not recommended at this time.
+The above minimal configuration can accomodate a small office or group of up to 50 users and up to 25 concurrently active and moderate level of mixed uploads, sharing, and bot activites. This is based on a managed MongoDB service (such as [mlab.com](https://mlab.com)). Running mongo local to a Pi is not recommended at this time.


### PR DESCRIPTION
Since it is currently relative interpreted and rendered as `https://rocket.chat/docs/master/mlab.com` instead of `https://mlab.com`.