### PR TITLE
ansible-galaxy install fails without `-p roles/`

### DIFF
--- a/3. Installation/5. Automation Tools/Ansible/README.md
+++ b/3. Installation/5. Automation Tools/Ansible/README.md
@@ -129,7 +129,7 @@ If you're running Ansible 2.0, paste the following into your `requirements.yml`:
 ```
 
 Next, let's fetch the Rocket.Chat Ansible role using the `ansible-galaxy` command:
-`~/ansible $ ansible-galaxy install -r roles/requirements.yml`
+`~/ansible $ ansible-galaxy install -p roles/ -r roles/requirements.yml`
 This command says "Hey, I want to install any roles I have defined in `requirements.yml`".
 Hopefully, after a couple seconds, you should have the `RocketChat.Server` role in your `roles` directory:
 ```


### PR DESCRIPTION
Without adding `-p roles/` to `~/ansible $ ansible-galaxy install -p roles/ -r roles/requirements.yml` ansible attempts (as a normal user) to install the role in /etc/ansible by default. The following error is: 
- extracting RocketChat.Server to /etc/ansible/roles/RocketChat.Server
  [WARNING]: - RocketChat.Server was NOT installed successfully: Could not update files in
  /etc/ansible/roles/RocketChat.Server: [Errno 13] Permission denied: '/etc/ansible'
