### PR TITLE
Github.md: Added a push(request) handler

### DIFF
--- a/4. Administrator Guides/Integrations/GitHub.md
+++ b/4. Administrator Guides/Integrations/GitHub.md
@@ -157,7 +157,71 @@ const githubEvents = {
         attachments: [attachment]
       }
     };
-  }
+  },
+
+  //// Github push event
+  push(request) {
+    var commits = request.content.commits;
+    var multi_commit = ""
+    var is_short = true;
+    var changeset = 'Changeset';
+    if ( commits.length > 1 ) {
+      var multi_commit = " [Multiple Commits]";
+      var is_short = false;
+      var changeset = changeset + 's';
+      var output = [];
+    }
+    const user = request.content.sender;
+    const attachment = {
+      author_icon: 'https://cloud.githubusercontent.com/assets/51996/13893698/c047133c-ed2e-11e5-9233-13622bcb9b7b.png',
+      author_name: "Message: " + request.content.head_commit.message + multi_commit,
+      author_link: request.content.compare,
+      fields: []
+    };
+
+    if (request.content.repository.full_name) {
+      attachment.fields.push({
+        title: 'Repo',
+        value: "["+request.content.repository.full_name+"]("+request.content.repository.url+")",
+        short: is_short
+      });
+    }
+
+    for (var i = 0; i < commits.length; i++) {
+      var commit = commits[i];
+      var shortID = commit.id.substring(0,7);
+      if ( commits.length > 1 ) {
+        a = '[' + shortID + '](' + commit.url + ') - ' + commit.message;
+        output.push( a );
+      } else {
+        var output = "["+shortID+"]("+commit.url+")";
+      }
+    }
+    if (commits.length > 1) {
+      attachment.fields.push({
+        title: changeset,
+        value: output.reverse().join('<br />'),
+        short: is_short
+      });
+    } else {
+      attachment.fields.push({
+        title: changeset,
+        value: output,
+        short: is_short
+      });
+    }
+
+    const text = ':ballot_box_with_check: Pushed to ' + "["+request.content.ref.split('/').pop()+"]";
+
+    return {
+      content: {
+        icon_url: user.avatar_url,
+        alias: user.login,
+        text: text,
+        attachments: [attachment]
+      }
+	};
+  },  // End Github Push
 };
 
 class Script {


### PR DESCRIPTION
![screenshot_20160606_114721](https://cloud.githubusercontent.com/assets/10273878/15829910/d5ba6590-2be3-11e6-8c23-d220bfa25cd8.png)

The image should explain most of it, I tried to come up with the best way to display single and multiple-commit push events.

Notable points: 
1. "Pushed to" displays the branch name
2. Format changes from `short:true` to `short:false` based on singular or multiple commits per push
3. Singular commits per push have a more linear style
4. Message is clickable as a link to the changeset
5. Hashes are clickable as a link to the commit
6. Repo is clickable as a link to the repo
