### PR TITLE
Add description about new push(), minor spelling and punctuation changes

### DIFF
--- a/4. Administrator Guides/Integrations/GitHub.md
+++ b/4. Administrator Guides/Integrations/GitHub.md
@@ -4,7 +4,7 @@ We can do 2 types of integrations with GitHub:
 2. Send commands to GitHub and optionally receive a response (**Outgoing WebHook**)
 
 ### Receive alerts
-* Create a new **incoming webhook**
+* Create a new **Incoming WebHook**
 * Select the channel were you will receive the alerts
 * Enable Scripts
 * Use this script to receive alerts from:
@@ -244,23 +244,25 @@ class Script {
   }
 }
 ```
+
 * Save the integration
-* Go to your repository `settings -> webhooks & services -> add webhook`
-* Paste your **Webhook URL** from Rocket.Chat into **Payload URL**
-* Keep **Contenty type** as `application/json`
+* Go to your repository `Settings -> WebHooks & services -> Add WebHook`
+* Paste your **WebHook URL** from Rocket.Chat into **Payload URL**
+* Keep **Content type** as `application/json`
 * Leave **Secret** empty and save
 
-
 ### Send commands to GitHub
+
 ```
 This script only works for public repositories
 ```
 
-* Create a new **outgoing webhook**
+* Create a new **Outgoing WebHook**
 * Select the channel where you will use the commands and receive the responses
 * Set **URLs** as `https://api.github.com/repos/User-Or-Org-Name/Repo-Name` like `https://api.github.com/repos/RocketChat/Rocket.Chat`
 * Enable Scripts
 * Use this **Script** to listen for commands `pr ls`, `pr list` and `help`
+
 ```javascript
 /* exported Script */
 /* globals Store */
@@ -321,4 +323,5 @@ class Script {
   }
 }
 ```
+
 * Save your integration

--- a/4. Administrator Guides/Integrations/GitHub.md
+++ b/4. Administrator Guides/Integrations/GitHub.md
@@ -7,7 +7,11 @@ We can do 2 types of integrations with GitHub:
 * Create a new **incoming webhook**
 * Select the channel were you will receive the alerts
 * Enable Scripts
-* Use this script to receive alerts from new issues, closed issues and comments
+* Use this script to receive alerts from:
+	* New and closed issue events
+	* Comment events (issues only)
+	* Push events (singular and multiple commits)
+
 ```javascript
 /* exported Script */
 


### PR DESCRIPTION
 68fb057 - Forgot to add to the description during my commit of the push() function. (I forgot it was the same repo, my bad) 

 eadad4e - Some minor spelling or punctuation changes and some whitespace between code paragraphs
