### PR TITLE
GitHub.md: Input script, switch out image URLs for inline SVGs

### DIFF
--- a/4. Administrator Guides/Integrations/GitHub.md
+++ b/4. Administrator Guides/Integrations/GitHub.md
@@ -11,6 +11,13 @@ We can do 2 types of integrations with GitHub:
 ```javascript
 /* exported Script */
 
+// Begin embedded images
+const gh_cmit_svg = '<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="octicon octicon-git-commit" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"></path></svg>';
+const gh_pr_svg = '<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="octicon octicon-git-pull-request" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>';
+const gh_iss_svg = '<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="octicon octicon-issue-opened" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"></path></svg>';
+const svg_inline_prefix = 'data:image/svg+xml;ascii,';
+// End embedded images
+
 const getLabelsField = (labels) => {
   let labelsArray = [];
   labels.forEach(function(label) {
@@ -36,7 +43,7 @@ const githubEvents = {
   issues(request) {
     const user = request.content.sender;
     const attachment = {
-      author_icon: 'https://cloud.githubusercontent.com/assets/51996/13893698/c047133c-ed2e-11e5-9233-13622bcb9b7b.png',
+      author_icon: svg_inline_prefix + gh_iss_svg,
       author_name: '#' + request.content.issue.number + ' - ' + request.content.issue.title,
       author_link: request.content.issue.html_url,
       fields: []
@@ -80,7 +87,7 @@ const githubEvents = {
   issue_comment(request) {
     const user = request.content.comment.user;
     var attachment = {
-      author_icon: 'https://cloud.githubusercontent.com/assets/51996/13893698/c047133c-ed2e-11e5-9233-13622bcb9b7b.png',
+      author_icon: svg_inline_prefix + gh_iss_svg,
       author_name: '#' + request.content.issue.number + ' - ' + request.content.issue.title,
       author_link: request.content.comment.html_url,
       fields: []
@@ -113,7 +120,7 @@ const githubEvents = {
   pull_request(request) {
     const user = request.content.sender;
     const attachment = {
-      author_icon: 'https://cloud.githubusercontent.com/assets/51996/13893698/c047133c-ed2e-11e5-9233-13622bcb9b7b.png',
+      author_icon: svg_inline_prefix + gh_pr_svg,
       author_name: '#' + request.content.pull_request.number + ' - ' + request.content.pull_request.title,
       author_link: request.content.pull_request.html_url
     };
@@ -173,7 +180,7 @@ const githubEvents = {
     }
     const user = request.content.sender;
     const attachment = {
-      author_icon: 'https://cloud.githubusercontent.com/assets/51996/13893698/c047133c-ed2e-11e5-9233-13622bcb9b7b.png',
+	  author_icon: svg_inline_prefix + gh_cmit_svg,
       author_name: "Message: " + request.content.head_commit.message + multi_commit,
       author_link: request.content.compare,
       fields: []


### PR DESCRIPTION
Please don't merge yet. My intention was originally to keep the embedded SVG in <svg> format, but I couldn't figure out how to get `Buffer` working with meteor. I kept getting `ReferenceError: Buffer is not defined` - which was when I realized I was following NodeJS instructions :/ 

If someone can figure out the proper way to encode the svg data into base64 on the fly, let me know. 

My original assumtion was that i could use:

```
var svg_item_1 = Buffer('<svg></svg>', 'ascii'); 
...
    author_icon: svg_b64_pre + svg_item_1.toString('base64');
```

but like I said, that didn't work? 

---

The original intention here was to include the `commit` icon because previously only the pull request icon was being used. Issue icon will be coming next. 
