### PR TITLE
Added the env Accounts_UseDNSDomainCheck=false to docker example

### DIFF
--- a/3. Installation/3. Docker Containers/README.md
+++ b/3. Installation/3. Docker Containers/README.md
@@ -268,6 +268,7 @@ rocketchat:
   environment:
     - MONGO_URL=mongodb://db:27017/rocketchat
     - ROOT_URL=https://chat.inumio.com
+#   - Accounts_UseDNSDomainCheck=True
   links:
     - db:db
   ports:
@@ -292,6 +293,7 @@ hubot:
 * Edit the ROOT_URL value to be your FQDN.
 * Edit the ROCKETCHAT_URL to be your *public* IP address. Keep the port (3000) the same.
 * Edit ROCKETCHAT_USER, ROCKETCHAT_PASSWORD, and BOT_NAME.
+* If your Rocket.Chat docker instance is behind a proxy, set the additional env-variable "Accounts_UseDNSDomainCheck" to "false" (this only works, if these is a completely new deployment)
 
 Save and Exit.
 


### PR DESCRIPTION
Added Description for the env "Accounts_UseDNSDomainCheck=false" that is need behind a proxy in order to create the first admin account.
