### PR TITLE
Update mongodb-org package for Debian to 3.2

### DIFF
--- a/3. Installation/4. Manual Installation/Debian/README.md
+++ b/3. Installation/4. Manual Installation/Debian/README.md
@@ -11,7 +11,7 @@ This guide explains how to deploy your own Rocket.Chat instance to a Debian Whee
 
 ```shell
 # SYSTEM CONFIGURATION
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 # Here use wheezy even if you are installing it on Jessie. 
 # since Jessie repository of Mongodb does NOT includes mongodb 3.2
 echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list

--- a/3. Installation/4. Manual Installation/Debian/README.md
+++ b/3. Installation/4. Manual Installation/Debian/README.md
@@ -13,8 +13,8 @@ This guide explains how to deploy your own Rocket.Chat instance to a Debian Whee
 # SYSTEM CONFIGURATION
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 # Here use wheezy even if you are installing it on Jessie. 
-# since Jessie repository of Mongodb does NOT includes mongodb 3.0
-echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+# since Jessie repository of Mongodb does NOT includes mongodb 3.2
+echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 sudo apt-get update
 sudo apt-get install -y mongodb-org curl graphicsmagick
 


### PR DESCRIPTION
I confirm that Rocket chat works on MongoDB 3.2.
