### PR TITLE
README.md - Landing page links to chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Rocket.Chat Docs
+## What would you like to do?
+
+* [Learn how to use rocket chat](https://rocket.chat/docs/user-guides)
+* [Get support](https://rocket.chat/docs/getting-support)
+* [Contribute to the project](https://rocket.chat/docs/contributing/)
+* [Install Rocket.chat](https://rocket.chat/docs/installation)
+* [Adminstrate your installation](https://rocket.chat/docs/administrator-guides)
+* [- or join in its development](https://rocket.chat/docs/developer-guides)
 
 ![image](mockup.png)
 
@@ -7,3 +15,8 @@
 Rocket.Chat is a Web Chat Server, developed in JavaScript, using the [Meteor](https://www.meteor.com/install) fullstack framework.
 
 It is a great solution for communities and companies wanting to privately host their own chat service or for developers looking forward to build and evolve their own chat platforms.
+
+
+
+
+


### PR DESCRIPTION
Optimally when you click on docs - you immediately know where to look to find your answer. I think adding these links to the top would improve the landing page, because you don't have to scroll to find the user guide, for instance. Ideally the screenshot would be to the right of the link, or the links would be buttons spanning horisontally, because in my proposal I think the page looks imbalanced with narrow lists on top and the huge image below (this is on a wide screen device). As the page looks before my proposal, I think it looks better on mobile, the image is smaller.
