### PR TITLE
Fixed addon plan for logentries in Heroku command

### DIFF
--- a/3. Installation/2. PaaS Deployments/Heroku/README.md
+++ b/3. Installation/2. PaaS Deployments/Heroku/README.md
@@ -35,7 +35,7 @@ git clone https://github.com/RocketChat/Rocket.Chat
 Change into the `Rocket.Chat` directory, and create your Heroku app:
 
 ```
-heroku apps:create  --addons mongolab:sandbox,logentries:tryit -b https://github.com/RocketChat/heroku-buildpack-meteor <your app name>
+heroku apps:create  --addons mongolab:sandbox,logentries:le_tryit -b https://github.com/RocketChat/heroku-buildpack-meteor <your app name>
 ```
 
 Choose \<your app name> carefully, as your Rocket.Chat will then be accessible at:


### PR DESCRIPTION
The plan for `logentries` was incorrectly specified as `tryit` instead of `le_tryit`
