### PR TITLE
Update Galaxy deployment instructions with version 2.2.2 for ansible 2.0

### DIFF
--- a/3. Installation/5. Automation Tools/Ansible/README.md
+++ b/3. Installation/5. Automation Tools/Ansible/README.md
@@ -125,7 +125,7 @@ If you're running Ansible 1.9.4, paste the following into your `requirements.yml
 If you're running Ansible 2.0, paste the following into your `requirements.yml`:
 ``` yaml
   - src: RocketChat.Server
-    version: v2.0
+    version: v2.2.2
 ```
 
 Next, let's fetch the Rocket.Chat Ansible role using the `ansible-galaxy` command:


### PR DESCRIPTION
The version 2.0 of the Galaxy RocketChat.Server role is not up-to-date and using older hashsum and it  fails during the tasks execution. Version 2.2.2 fixes it.
