### PR TITLE
Update README.md -  fix wrong command for installing/changing node version

### DIFF
--- a/3. Installation/7. Updating/1. From 0.x.x to 0.40.0/README.md
+++ b/3. Installation/7. Updating/1. From 0.x.x to 0.40.0/README.md
@@ -11,7 +11,7 @@ First stop Rocket.Chat
 The guides suggest the usage of `n` to manage Node.js version.  Assuming that is what you used run:
 
 ```
-sudo n install 4.5
+sudo n 4.5
 ```
 
 Then follow the upgrade steps of your chosen method like normal:


### PR DESCRIPTION
Using `n install 4.5` results in a `Error: invalid version install.`
`n 4.5` works for changing the version.
