### PR TITLE
Update uptimerobot.md

### DIFF
--- a/5. Administrator Guides/Integrations/uptimerobot.md
+++ b/5. Administrator Guides/Integrations/uptimerobot.md
@@ -4,7 +4,7 @@ Add UptimeRobot notifications via a new WebHook in RocketChat
 3. Follow all instructions like Enable, give it a name, link to channel etc. Set "Enable Script" to true and enter the javascript in the "Script" box
 4. Press Save changes and copy the *Webhook URL* (added just below the script box)
 5. Go to UptimeRobot.com -> MySettings -> Add Alert Contact -> Select Alert contact type: "Web-Hook"
-6. Paste the Rocket.Chat url you've copied in step 4, and add an "&" at the end of the URL in the "URL to Notify" field
+6. Paste the Rocket.Chat url you've copied in step 4, and add an "?" at the end of the URL in the "URL to Notify" field
 7. Paste the following in the "POST Value (JSON Format)" field:
 
 ```


### PR DESCRIPTION
For this documentation work properly, change step 6 as present below:

Using the "&" the incoming webhook request a login credentials: and display this message: `{"status":"error","message":"You must be logged in to do this."}`

The correct character is: ?
*And Using the "?" it will work: *

Bellow is the information from uptimerobot:
So, make sure that the URL added ends with

```
*?* (if it doesn't have a querystring) or
*&* (if it already has a querystring)
```

to make it a valid request.

I tested this procedure 4 times in my production environment.
