### PR TITLE
Update CentOS README.md with additional dependency

### DIFF
--- a/3. Installation/4. Manual Installation/CentOS/README.md
+++ b/3. Installation/4. Manual Installation/CentOS/README.md
@@ -35,7 +35,7 @@ CTRL-O, CTRL-X
 Now we need to install our dependencies from yum:
 
 ```
-yum install -y nodejs curl GraphicsMagick npm mongodb-org-server mongodb-org
+yum install -y nodejs curl GraphicsMagick npm mongodb-org-server mongodb-org gcc-c++
 ```
 
 Now that we have Node.js and npm installed, we need to install a few more dependencies:


### PR DESCRIPTION
The package gcc-c++ is not installed on all installations of CentOS/RHEL by default, which can lead to confusing errors about npm install having issues with fibers. Including gcc-c++ solves this issue.
