### PR TITLE
Recommend `npm start` instead of `meteor`

### DIFF
--- a/6. Developer Guides/01. Pre-Requisites/README.md
+++ b/6. Developer Guides/01. Pre-Requisites/README.md
@@ -9,7 +9,7 @@ Prerequisites:
 ```
 git clone https://github.com/RocketChat/Rocket.Chat.git
 cd Rocket.Chat
-meteor
+npm start
 ```
 
 If you have any problems with the above commands, please, see the [troubleshooting](/6.%20Developer%20Guides/11.%20Troubleshooting)


### PR DESCRIPTION
Recent changes to how we are pulling in packages requires the usage of `npm start` instead of using `meteor`, so that `meteor npm install` is ran.

@RocketChat/core 