### PR TITLE
Add the missing documentation for the Rest API

### DIFF
--- a/6. Developer Guides/REST API/Channels/README.md
+++ b/6. Developer Guides/REST API/Channels/README.md
@@ -6,6 +6,8 @@ order: 30
 | Url | Short Description | Details Page |
 | :--- | :--- | :--- |
 | `/api/v1/channels.addAll` | Adds all of the users on the server to a channel. | [Link](addAll.md) |
+| `/api/v1/channels.addModerator` | Gives the role of moderator to a user in a channel. | [Link](addModerator.md) |
+| `/api/v1/channels.addOwner` | Gives the role of owner to a user in a channel. | [Link](addOwner.md) |
 | `/api/v1/channels.archive` | Archives a channel. | [Link](archive.md) |
 | `/api/v1/channels.cleanHistory` | Cleans up a channel's history, requires special permission. | [Link](cleanHistory.md) |
 | `/api/v1/channels.close` | Removes a channel from a user's list of channels. | [Link](close.md) |
@@ -19,6 +21,8 @@ order: 30
 | `/api/v1/channels.list` | Retrives all of the channels from the server. | [Link](list.md) |
 | `/api/v1/channels.list.joined` | Gets only the channels the calling user has joined. | [Link](list.joined.md) |
 | `/api/v1/channels.open` | Adds the channel back to the user's list of channels. | [Link](open.md) |
+| `/api/v1/channels.removeModerator` | Removes the role of moderator from a user in a channel. | [Link](removeModerator.md) |
+| `/api/v1/channels.removeOwner` | Removes the role of owner from a user in a channel. | [Link](removeOwner.md) |
 | `/api/v1/channels.rename` | Changes a channel's name. | [Link](rename.md) |
 | `/api/v1/channels.setDescription` | Sets a channel's description. | [Link](setDescription.md) |
 | `/api/v1/channels.setJoinCode` | Sets the channel's code required to join it. | [Link](setJoinCode.md) |

--- a/6. Developer Guides/REST API/Channels/addModerator.md
+++ b/6. Developer Guides/REST API/Channels/addModerator.md
@@ -1,0 +1,38 @@
+---
+order: 3
+---
+
+# Channel Add Moderator
+Gives the role of moderator for a user in the currrent channel.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/channels.addModerator` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The channel's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/channels.addModerator \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Channels/addOwner.md
+++ b/6. Developer Guides/REST API/Channels/addOwner.md
@@ -1,0 +1,38 @@
+---
+order: 4
+---
+
+# Channel Add Owner
+Gives the role of owner for a user in the currrent channel.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/channels.addOwner` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The channel's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/channels.addOwner \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Channels/history.md
+++ b/6. Developer Guides/REST API/Channels/history.md
@@ -9,7 +9,7 @@ Retrieves the messages from a channel.
 | :--- | :--- | :--- |
 | `/api/v1/channels.history` | `yes` | `GET` |
 
-## Payload
+## Query Parameters
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `roomId` | `ByehQjC44FwMeiLbX` | Required | The channel's id |

--- a/6. Developer Guides/REST API/Channels/removeModerator.md
+++ b/6. Developer Guides/REST API/Channels/removeModerator.md
@@ -1,0 +1,38 @@
+---
+order: 63
+---
+
+# Channel Remove Moderator
+Removes the role of moderator from a user in the currrent channel.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/channels.removeModerator` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The channel's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user's id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/channels.removeModerator \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Channels/removeOwner.md
+++ b/6. Developer Guides/REST API/Channels/removeOwner.md
@@ -1,0 +1,38 @@
+---
+order: 64
+---
+
+# Channel Remove Owner
+Removes the role of owner from a user in the currrent channel.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/channels.removeOwner` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The channel's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user's id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/channels.removeOwner \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Groups/README.md
+++ b/6. Developer Guides/REST API/Groups/README.md
@@ -18,6 +18,8 @@ order: 40
 | `/api/v1/groups.leave` | Removes the calling user from the private group. | [Link](leave.md) |
 | `/api/v1/groups.list` | List the private groups the caller is part of. | [Link](list.md) |
 | `/api/v1/groups.open` | Adds the private group back to the list of groups. | [Link](open.md) |
+| `/api/v1/groups.removeModerator` | Removes the role of moderator from a user in a group. | [Link](removeModerator.md) |
+| `/api/v1/groups.removeOwner` | Removes the role of owner from a user in a group. | [Link](removeOwner.md) |
 | `/api/v1/groups.rename` | Changes the name of the private group. | [Link](rename.md) |
 | `/api/v1/groups.setDescription` | Sets a private group's description. | [Link](setDescription.md) |
 | `/api/v1/groups.setPurpose` | Sets a private group's description. | [Link](setPurpose.md) |

--- a/6. Developer Guides/REST API/Groups/README.md
+++ b/6. Developer Guides/REST API/Groups/README.md
@@ -5,6 +5,8 @@ order: 40
 # Group Methods
 | Url | Short Description | Details Page |
 | :--- | :--- | :--- |
+| `/api/v1/groups.addModerator` | Gives the role of moderator to a user in a group. | [Link](addModerator.md) |
+| `/api/v1/groups.addOwner` | Gives the role of owner to a user in a group. | [Link](addOwner.md) |
 | `/api/v1/groups.archive` | Archives a private group. | [Link](archive.md) |
 | `/api/v1/groups.close` | Removes a private group from the list of groups. | [Link](close.md) |
 | `/api/v1/groups.create` | Creates a new private group. | [Link](create.md) |

--- a/6. Developer Guides/REST API/Groups/addModerator.md
+++ b/6. Developer Guides/REST API/Groups/addModerator.md
@@ -1,0 +1,38 @@
+---
+order: 3
+---
+
+# Group Add Moderator
+Gives the role of moderator for a user in the currrent group.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/groups.addModerator` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The private group's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/groups.addModerator \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Groups/addOwner.md
+++ b/6. Developer Guides/REST API/Groups/addOwner.md
@@ -1,0 +1,38 @@
+---
+order: 4
+---
+
+# Group Add Owner
+Gives the role of owner for a user in the currrent group.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/groups.addOwner` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The private group's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/groups.addOwner \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Groups/history.md
+++ b/6. Developer Guides/REST API/Groups/history.md
@@ -9,7 +9,7 @@ Retrieves the messages from a private group, only if you're part of the group.
 | :--- | :--- | :--- |
 | `/api/v1/groups.history` | `yes` | `GET` |
 
-## Payload
+## Query Parameters
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `roomId` | `ByehQjC44FwMeiLbX` | Required | The private groups's id |

--- a/6. Developer Guides/REST API/Groups/info.md
+++ b/6. Developer Guides/REST API/Groups/info.md
@@ -9,7 +9,7 @@ Retrieves the information about the private group, only if you're part of the gr
 | :--- | :--- | :--- |
 | `/api/v1/groups.info` | `yes` | `GET` |
 
-## Payload
+## Query Parameters
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `roomId` | `ByehQjC44FwMeiLbX` | Required | The private group's id |

--- a/6. Developer Guides/REST API/Groups/removeModerator.md
+++ b/6. Developer Guides/REST API/Groups/removeModerator.md
@@ -1,0 +1,38 @@
+---
+order: 63
+---
+
+# Group Remove Moderator
+Removes the role of moderator from a user in the currrent group.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/groups.removeModerator` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The private group's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user's id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/groups.removeModerator \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Groups/removeOwner.md
+++ b/6. Developer Guides/REST API/Groups/removeOwner.md
@@ -1,0 +1,38 @@
+---
+order: 54
+---
+
+# Group Remove Owner
+Removes the role of owner from a user in the currrent Group.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/groups.removeOwner` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The private group's id |
+| `userId` | `nSYqWzZ4GsKTX4dyK` | Required | The user's id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/groups.removeOwner \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "userId": "nSYqWzZ4GsKTX4dyK" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.4 | Added |
+

--- a/6. Developer Guides/REST API/Im/README.md
+++ b/6. Developer Guides/REST API/Im/README.md
@@ -2,7 +2,7 @@
 order: 40
 ---
 
-# Im Methods
+# IM Methods
 | Url | Short Description | Details Page |
 | :--- | :--- | :--- |
 | `/api/v1/im.close` | Removes a direct message from the list of direct messages. | [Link](close.md) |

--- a/6. Developer Guides/REST API/Im/README.md
+++ b/6. Developer Guides/REST API/Im/README.md
@@ -1,0 +1,17 @@
+---
+order: 40
+---
+
+# Im Methods
+| Url | Short Description | Details Page |
+| :--- | :--- | :--- |
+| `/api/v1/im.close` | Removes a direct message from the list of direct messages. | [Link](close.md) |
+| `/api/v1/im.history` | Retrieves the messages from a direct message. | [Link](history.md) |
+| `/api/v1/im.messages.others` | Retrieves the messages from any direct message in the server. | [Link](messages.others.md) |
+| `/api/v1/im.list` | List the direct messages the caller is part of. | [Link](list.md) |
+| `/api/v1/im.list.everyone` | List all direct message the caller in the server. | [Link](list.everyone.md) |
+| `/api/v1/im.open` | Adds the direct message back to the list of direct messages. | [Link](open.md) |
+| `/api/v1/im.setTopic` | Sets a direct message topic. | [Link](setTopic.md) |
+
+From version 0.50.0 and on you can call the methods using `dm` instead of `im`.
+

--- a/6. Developer Guides/REST API/Im/README.md
+++ b/6. Developer Guides/REST API/Im/README.md
@@ -13,5 +13,6 @@ order: 40
 | `/api/v1/im.open` | Adds the direct message back to the list of direct messages. | [Link](open.md) |
 | `/api/v1/im.setTopic` | Sets a direct message topic. | [Link](setTopic.md) |
 
+## Notes
 From version 0.50.0 and on you can call the methods using `dm` instead of `im`.
 

--- a/6. Developer Guides/REST API/Im/close.md
+++ b/6. Developer Guides/REST API/Im/close.md
@@ -2,7 +2,7 @@
 order: 5
 ---
 
-# Im Close
+# IM Close
 Removes the direct message from the user's list of direct messages.
 
 | URL | Requires Auth | HTTP Method |

--- a/6. Developer Guides/REST API/Im/close.md
+++ b/6. Developer Guides/REST API/Im/close.md
@@ -1,0 +1,36 @@
+---
+order: 5
+---
+
+# Im Close
+Removes the direct message from the user's list of direct messages.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/im.close` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The direct message id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/im.close \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.48.0 | Added |

--- a/6. Developer Guides/REST API/Im/history.md
+++ b/6. Developer Guides/REST API/Im/history.md
@@ -9,7 +9,7 @@ Retrieves the messages from a direct message.
 | :--- | :--- | :--- |
 | `/api/v1/im.history` | `yes` | `GET` |
 
-## Payload
+## Query Parameters
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `roomId` | `ByehQjC44FwMeiLbX` | Required | The direct message id |

--- a/6. Developer Guides/REST API/Im/history.md
+++ b/6. Developer Guides/REST API/Im/history.md
@@ -1,0 +1,91 @@
+---
+order: 10
+---
+
+# Im History
+Retrieves the messages from a direct message.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/im.history` | `yes` | `GET` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The direct message id |
+| `latest` | `2016-09-30T13:42:25.304Z` | Optional <br> Default: now | The end of time range of messages to retrieve |
+| `oldest` | `2016-05-30T13:42:25.304Z` | Optional <br> Default: _n/a_ | The start of the time range of messages to retrieve |
+| `inclusive` | `true` | Optional <br> Default: `false` | Whether messages which land on latest and oldest should be included |
+| `count` | `100` | Optional <br> Default: `20` | The amount of messages to retrieve |
+| `unreads` | `false` | Optional <br> Default: `false` | Whether the amount of unreads should be included. |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/im.history?roomId=ByehQjC44FwMeiLbX
+```
+
+## Example Result
+```json
+{
+  "messages": [
+    {
+      "_id": "AkzpHAvZpdnuchw2a",
+      "rid": "ByehQjC44FwMeiLbX",
+      "msg": "hi",
+      "ts": "2016-12-09T12:50:51.555Z",
+      "u": {
+        "_id": "y65tAmHs93aDChMWu",
+        "username": "testing"
+      },
+      "_updatedAt": "2016-12-09T12:50:51.562Z"
+    },
+    {
+      "_id": "vkLMxcctR4MuTxreF",
+      "t": "uj",
+      "rid": "ByehQjC44FwMeiLbX",
+      "ts": "2016-12-08T15:41:37.730Z",
+      "msg": "testing2",
+      "u": {
+        "_id": "bRtgdhzM6PD9F8pSx",
+        "username": "testing2"
+      },
+      "groupable": false,
+      "_updatedAt": "2016-12-08T16:03:25.235Z"
+    },
+    {
+      "_id": "bfRW658nEyEBg75rc",
+      "t": "uj",
+      "rid": "ByehQjC44FwMeiLbX",
+      "ts": "2016-12-07T15:47:49.099Z",
+      "msg": "testing",
+      "u": {
+        "_id": "nSYqWzZ4GsKTX4dyK",
+        "username": "testing1"
+      },
+      "groupable": false,
+      "_updatedAt": "2016-12-07T15:47:49.099Z"
+    },
+    {
+      "_id": "pbuFiGadhRZTKouhB",
+      "t": "uj",
+      "rid": "ByehQjC44FwMeiLbX",
+      "ts": "2016-12-06T17:57:38.635Z",
+      "msg": "testing",
+      "u": {
+        "_id": "y65tAmHs93aDChMWu",
+        "username": "testing"
+      },
+      "groupable": false,
+      "_updatedAt": "2016-12-06T17:57:38.635Z"
+    }
+  ],
+  "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.48.0 | Added |

--- a/6. Developer Guides/REST API/Im/history.md
+++ b/6. Developer Guides/REST API/Im/history.md
@@ -2,7 +2,7 @@
 order: 10
 ---
 
-# Im History
+# IM History
 Retrieves the messages from a direct message.
 
 | URL | Requires Auth | HTTP Method |

--- a/6. Developer Guides/REST API/Im/list.everyone.md
+++ b/6. Developer Guides/REST API/Im/list.everyone.md
@@ -3,7 +3,7 @@ order: 20
 ---
 
 # IM List Everyone
-Lists all of the direct messages in the server, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
+Lists all of the direct messages in the server, requires the permission `view-room-administration` permission and this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
 
 | URL | Requires Auth | HTTP Method |
 | :--- | :--- | :--- |

--- a/6. Developer Guides/REST API/Im/list.everyone.md
+++ b/6. Developer Guides/REST API/Im/list.everyone.md
@@ -1,0 +1,65 @@
+---
+order: 20
+---
+
+# Im List.Eeveryone
+Lists all of the direct messages in the server, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/im.list.everyone` | `yes` | `GET` |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/im.list.everyone
+```
+
+## Example Result
+```json
+{
+    "ims": [
+        {
+            "_id": "ByehQjC44FwMeiLbX",
+            "name": "test-test",
+            "t": "p",
+            "usernames": [
+                "testing1"
+            ],
+            "msgs": 0,
+            "u": {
+                "_id": "aobEdbYhXfu5hkeqG",
+                "username": "testing1"
+            },
+            "ts": "2016-12-09T15:08:58.042Z",
+            "ro": false,
+            "sysMes": true,
+            "_updatedAt": "2016-12-09T15:22:40.656Z"
+        },
+        {
+            "_id": "t7qapfhZjANMRAi5w",
+            "name": "testing",
+            "t": "p",
+            "usernames": [
+                "testing2"
+            ],
+            "msgs": 0,
+            "u": {
+                "_id": "y65tAmHs93aDChMWu",
+                "username": "testing2"
+            },
+            "ts": "2016-12-01T15:08:58.042Z",
+            "ro": false,
+            "sysMes": true,
+            "_updatedAt": "2016-12-09T15:22:40.656Z"
+        }
+    ],
+    "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.0 | Added |

--- a/6. Developer Guides/REST API/Im/list.everyone.md
+++ b/6. Developer Guides/REST API/Im/list.everyone.md
@@ -2,7 +2,7 @@
 order: 20
 ---
 
-# Im List.Eeveryone
+# IM List Everyone
 Lists all of the direct messages in the server, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
 
 | URL | Requires Auth | HTTP Method |

--- a/6. Developer Guides/REST API/Im/list.md
+++ b/6. Developer Guides/REST API/Im/list.md
@@ -1,0 +1,66 @@
+---
+order: 15
+---
+
+# Im List
+Lists all of the direct messages the calling user has joined, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/im.list` | `yes` | `GET` |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/im.list
+```
+
+## Example Result
+```json
+{
+    "ims": [
+        {
+            "_id": "ByehQjC44FwMeiLbX",
+            "name": "test-test",
+            "t": "p",
+            "usernames": [
+                "testing1"
+            ],
+            "msgs": 0,
+            "u": {
+                "_id": "aobEdbYhXfu5hkeqG",
+                "username": "testing1"
+            },
+            "ts": "2016-12-09T15:08:58.042Z",
+            "ro": false,
+            "sysMes": true,
+            "_updatedAt": "2016-12-09T15:22:40.656Z"
+        },
+        {
+            "_id": "t7qapfhZjANMRAi5w",
+            "name": "testing",
+            "t": "p",
+            "usernames": [
+                "testing2"
+            ],
+            "msgs": 0,
+            "u": {
+                "_id": "y65tAmHs93aDChMWu",
+                "username": "testing2"
+            },
+            "ts": "2016-12-01T15:08:58.042Z",
+            "ro": false,
+            "sysMes": true,
+            "_updatedAt": "2016-12-09T15:22:40.656Z"
+        }
+    ],
+    "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.49.0 | Count and offset query parameters supported. |
+| 0.48.0 | Added |

--- a/6. Developer Guides/REST API/Im/list.md
+++ b/6. Developer Guides/REST API/Im/list.md
@@ -2,7 +2,7 @@
 order: 15
 ---
 
-# Im List
+# IM List
 Lists all of the direct messages the calling user has joined, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
 
 | URL | Requires Auth | HTTP Method |

--- a/6. Developer Guides/REST API/Im/messages.others.md
+++ b/6. Developer Guides/REST API/Im/messages.others.md
@@ -11,7 +11,7 @@ For this method work the `Enable Direct Message History Endpoint` setting must b
 | :--- | :--- | :--- |
 | `/api/v1/im.messages.others` | `yes` | `GET` |
 
-## Payload
+## Query Parameters
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `roomId` | `ByehQjC44FwMeiLbX` | Required | The direct message id |

--- a/6. Developer Guides/REST API/Im/messages.others.md
+++ b/6. Developer Guides/REST API/Im/messages.others.md
@@ -5,7 +5,7 @@ order: 25
 # IM Messages Others
 Retrieves the messages from any direct message in the server, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
 
-For this method work the `Enable Direct Message History Endpoint` setting must be true, and the user calling this method must have the `view-room-administration` permission.
+For this method to work the `Enable Direct Message History Endpoint` setting must be true, and the user calling this method must have the `view-room-administration` permission.
 
 | URL | Requires Auth | HTTP Method |
 | :--- | :--- | :--- |

--- a/6. Developer Guides/REST API/Im/messages.others.md
+++ b/6. Developer Guides/REST API/Im/messages.others.md
@@ -2,7 +2,7 @@
 order: 25
 ---
 
-# Im Messages.others
+# IM Messages Others
 Retrieves the messages from any direct message in the server, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
 
 For this method work the `Enable Direct Message History Endpoint` setting must be true, and the user calling this method must have the `view-room-administration` permission.

--- a/6. Developer Guides/REST API/Im/messages.others.md
+++ b/6. Developer Guides/REST API/Im/messages.others.md
@@ -1,0 +1,88 @@
+---
+order: 25
+---
+
+# Im Messages.others
+Retrieves the messages from any direct message in the server, this method supports the [Offset and Count Query Parameters](../Offset%20and%20Count%20Info.md).
+
+For this method work the `Enable Direct Message History Endpoint` setting must be true, and the user calling this method must have the `view-room-administration` permission.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/im.messages.others` | `yes` | `GET` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The direct message id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/im.messages.others?roomId=ByehQjC44FwMeiLbX
+```
+
+## Example Result
+```json
+{
+  "messages": [
+    {
+      "_id": "AkzpHAvZpdnuchw2a",
+      "rid": "ByehQjC44FwMeiLbX",
+      "msg": "hi",
+      "ts": "2016-12-09T12:50:51.555Z",
+      "u": {
+        "_id": "y65tAmHs93aDChMWu",
+        "username": "testing"
+      },
+      "_updatedAt": "2016-12-09T12:50:51.562Z"
+    },
+    {
+      "_id": "vkLMxcctR4MuTxreF",
+      "t": "uj",
+      "rid": "ByehQjC44FwMeiLbX",
+      "ts": "2016-12-08T15:41:37.730Z",
+      "msg": "testing2",
+      "u": {
+        "_id": "bRtgdhzM6PD9F8pSx",
+        "username": "testing2"
+      },
+      "groupable": false,
+      "_updatedAt": "2016-12-08T16:03:25.235Z"
+    },
+    {
+      "_id": "bfRW658nEyEBg75rc",
+      "t": "uj",
+      "rid": "ByehQjC44FwMeiLbX",
+      "ts": "2016-12-07T15:47:49.099Z",
+      "msg": "testing",
+      "u": {
+        "_id": "nSYqWzZ4GsKTX4dyK",
+        "username": "testing1"
+      },
+      "groupable": false,
+      "_updatedAt": "2016-12-07T15:47:49.099Z"
+    },
+    {
+      "_id": "pbuFiGadhRZTKouhB",
+      "t": "uj",
+      "rid": "ByehQjC44FwMeiLbX",
+      "ts": "2016-12-06T17:57:38.635Z",
+      "msg": "testing",
+      "u": {
+        "_id": "y65tAmHs93aDChMWu",
+        "username": "testing"
+      },
+      "groupable": false,
+      "_updatedAt": "2016-12-06T17:57:38.635Z"
+    }
+  ],
+  "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.50.0 | Added |

--- a/6. Developer Guides/REST API/Im/open.md
+++ b/6. Developer Guides/REST API/Im/open.md
@@ -1,0 +1,36 @@
+---
+order: 30
+---
+
+# Channel Open
+Adds the direct message back to the user's list of direct messages.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/im.open` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The direct message id |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/im.open \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX" }'
+```
+
+## Example Result
+```json
+{
+   "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.48.0 | Added |

--- a/6. Developer Guides/REST API/Im/open.md
+++ b/6. Developer Guides/REST API/Im/open.md
@@ -2,7 +2,7 @@
 order: 30
 ---
 
-# Channel Open
+# IM Open
 Adds the direct message back to the user's list of direct messages.
 
 | URL | Requires Auth | HTTP Method |

--- a/6. Developer Guides/REST API/Im/setTopic.md
+++ b/6. Developer Guides/REST API/Im/setTopic.md
@@ -2,7 +2,7 @@
 order: 50
 ---
 
-# Im Set Topic
+# IM Set Topic
 Sets the topic for the direct message.
 
 | URL | Requires Auth | HTTP Method |

--- a/6. Developer Guides/REST API/Im/setTopic.md
+++ b/6. Developer Guides/REST API/Im/setTopic.md
@@ -1,0 +1,38 @@
+---
+order: 50
+---
+
+# Im Set Topic
+Sets the topic for the direct message.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/im.setTopic` | `yes` | `POST` |
+
+## Payload
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `roomId` | `ByehQjC44FwMeiLbX` | Required | The direct message id |
+| `topic` | `Discuss all of the testing.` | Required | The direct message topic to set. |
+
+## Example Call
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type: application/json" \
+     http://localhost:3000/api/v1/im.setTopic \
+     -d '{ "roomId": "ByehQjC44FwMeiLbX", "topic": "Discuss all of the testing" }'
+```
+
+## Example Result
+```json
+{
+  "topic": "Testing out everything.",
+  "success": true
+}
+```
+
+## Change Log
+| Version | Description |
+| :--- | :--- |
+| 0.48.0 | Added |


### PR DESCRIPTION
Will add the following missing API methods to the documentation:
### Channel
  - [x] addOwner
  - [x] addModerator
  - [x] removeOwner
  - [x] removeModerator

### Group
  - [x] addOwner
  - [x] addModerator
  - [x] removeOwner
  - [x] removeModerator

### Im
  - [x] setTopic
  - [x] history
  - [x] list
  - [x] list.everyone
  - [x] close
  - [x] open

@graywolf336 if you see something wrong or if someone else already done any of the items above, please let me know