### PR TITLE
Use the upstream definition for proxy pass

### DIFF
--- a/3. Installation/4. Manual Installation/Configuring SSL Reverse Proxy.md
+++ b/3. Installation/4. Manual Installation/Configuring SSL Reverse Proxy.md
@@ -41,7 +41,7 @@ server {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # don’t use SSLv3 ref: POODLE
 
     location / {
-        proxy_pass http://IP:3000/;
+        proxy_pass http://backend/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
You didn't have to provide an IP at proxy_pass because a upstream is defined