### PR TITLE
Updated REST API README to include link to Ruby wrapper implementation

### DIFF
--- a/1. Contributing/README.md
+++ b/1. Contributing/README.md
@@ -2,11 +2,11 @@
 
 There are multiple ways you can help.
 
-If you are a developer, you can start [contributing](/1.%20Contributing/developing/).
+If you are a developer, you can start [contributing](/1.%20Contributing/Developing/).
 
-If you are a blogger or news writer, please [promote us](/1.%20Contributing/promoting/).
+If you are a blogger or news writer, please [promote us](/1.%20Contributing/Promoting/).
 
-If you have found a security issue, [report it](/1.%20Contributing/security/) so we can make Rocket.Chat better and more secure for everyone.
+If you have found a security issue, [report it](/1.%20Contributing/Security/) so we can make Rocket.Chat better and more secure for everyone.
 
 If you want to help with documentation in this project, please visit [Rocket.Chat.Docs](https://github.com/RocketChat/Rocket.Chat.Docs). To preview changes locally use [the generator](https://github.com/RocketChat/Rocket.Chat.Docs.Generator).
 

--- a/6. Developer Guides/REST API/README.md
+++ b/6. Developer Guides/REST API/README.md
@@ -122,3 +122,6 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 
 ### Python
 * [rocketchat_API](https://github.com/jadolg/rocketchat_API)
+
+### Ruby
+* [rocketchat-ruby](https://github.com/abrom/rocketchat-ruby)


### PR DESCRIPTION
Also fixed a few 404's in the Contributing/README

There is another Ruby rocket.chat library implementation here: https://github.com/int2xx9/ruby-rocketchat  although it supports API ~v0.1 so it may add confusion in linking to it??