### PR TITLE
OpenShift: need to use the -p parameter multiple time when creating the app

### DIFF
--- a/3. Installation/2. PaaS Deployments/OpenShift/README.md
+++ b/3. Installation/2. PaaS Deployments/OpenShift/README.md
@@ -42,7 +42,7 @@ Clone the Rocket.Chat GitHub repository and import the templates to your OpenShi
 Create the application using the newly created templated and passing the `MONGODB_DATABASE`,`MONGODB_USER`
  and `MONGODB_PASSWORD` parameters: 
 ```bash
-# oc new-app rocket-chat -p MONGODB_DATABASE=rocketchat,MONGODB_USER=rocketchat-admin,MONGODB_PASSWORD=rocketchat
+# oc new-app rocket-chat -p MONGODB_DATABASE=rocketchat -p MONGODB_USER=rocketchat-admin -p MONGODB_PASSWORD=rocketchat
 ```
 
 * Rocket.Chat uses a domain check code to verify the validity of the e-mail address. To disable it, run the following commands:


### PR DESCRIPTION
Passing multiple parameters separated by commas is not supported anymore since OpenShift 1.4 released Nov 2016. Ref.: https://github.com/openshift/origin/pull/11539