### PR TITLE
Adding link to example script

### DIFF
--- a/6. Developer Guides/Realtime-API/README.md
+++ b/6. Developer Guides/Realtime-API/README.md
@@ -26,3 +26,5 @@ The type of communication is defined according to the call:
 
 [1]:1.%20Method%20Calls/
 [2]:2.%20Subscriptions/
+
+You can find a basic example script that uses the 'ddp' NodeJS package to subscribe to the Realtime-API stream of a Group/Channel here [https://github.com/jszaszvari/rocketchat-ddp-listener](https://github.com/jszaszvari/rocketchat-ddp-listener)


### PR DESCRIPTION
Adding link to example of a basic script that subscribes to a channel stream using the Realtime-API.