### PR TITLE
Link of end point for websocket

### DIFF
--- a/6. Developer Guides/Realtime-API/README.md
+++ b/6. Developer Guides/Realtime-API/README.md
@@ -4,7 +4,7 @@ order: 10
 
 # Realtime API
 
-__IMPORTANT!__ These docs are based on an unreleased version of the API. If you want to try it out, point your client to [http://demo.rocket.chat](http://demo.rocket.chat).
+__IMPORTANT!__ These docs are based on an unreleased version of the API. If you want to try it out, point your client to __wss://demo.rocket.chat/websocket__.
 
 Our realtime API is composed of two elements: [Method Calls][1] and [Subscriptions][2]. Both of them are supported directly in the websocket connection.
 


### PR DESCRIPTION
The endpoint URL should be wss://demo.rocket.chat/websocket . As, many have opened issues regaring URL.