### PR TITLE
Add support for GitLab 9.3 and above in GitLab integration snippet.

### DIFF
--- a/5. Administrator Guides/Integrations/GitLab.md
+++ b/5. Administrator Guides/Integrations/GitLab.md
@@ -54,7 +54,10 @@ class Script { // eslint-disable-line
 				case 'Pipeline Hook':
 					result = this.pipelineEvent(request.content);
 					break;
-				case 'Build Hook':
+				case 'Build Hook': // GitLab < 9.3
+					result = this.buildEvent(request.content);
+					break;
+				case 'Job Hook': // GitLab >= 9.3.0
 					result = this.buildEvent(request.content);
 					break;
 				case 'Wiki Page Hook':


### PR DESCRIPTION
Regarding #354, As GitLab 9.3.0 renamed the build push event to Job, I updated the custom script to support this. 

The content of the hook is exactly the same and the script has been tested internally.