### PR TITLE
Update recommended Node.js version from 4.5 to 4.8.4

### DIFF
--- a/3. Installation/4. Manual Installation/CentOS/README.md
+++ b/3. Installation/4. Manual Installation/CentOS/README.md
@@ -44,10 +44,10 @@ Now that we have Node.js and npm installed, we need to install a few more depend
 npm install -g inherits n
 ```
 
-Rocket.Chat needs Node.js version `4.5` using n we are going to install that version:
+The recommended Node.js version for using Rocket.Chat is `4.8.4`. Using _n_ we are going to install that version:
 
 ```
-n 4.5
+n 4.8.4
 ```
 
 ### Installing Rocket.Chat

--- a/3. Installation/4. Manual Installation/Debian/README.md
+++ b/3. Installation/4. Manual Installation/Debian/README.md
@@ -42,8 +42,8 @@ sudo apt-get install build-essential
 # Install a tool to let us change the node version.
 sudo npm install -g n
 
-# As of Version 0.49, Rocket.Chat needs version 4.7.1 of Node.js to work.
-sudo n 4.7.1
+# As of Version 0.49, Rocket.Chat recommends version 4.8.4 of Node.js.
+sudo n 4.8.4
 ```
 
 More on [nodejs installation](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-an-ubuntu-14-04-server)

--- a/3. Installation/4. Manual Installation/Ubuntu/README.md
+++ b/3. Installation/4. Manual Installation/Ubuntu/README.md
@@ -3,9 +3,9 @@
 ## Recommended Fastest Server Install via Snaps
 
 
-This is the easiest way for you to get your server up and running on all supported Linux (Ubuntu, etc).  
+This is the easiest way for you to get your server up and running on all supported Linux (Ubuntu, etc).
 
-Installing using: 
+Installing using:
 
 ```
 sudo snap install rocketchat-server
@@ -65,10 +65,10 @@ Install a tool to let us change the node version.
 sudo npm install -g n
 ```
 
-Rocket.Chat needs Node.js version 4.5
+The recommended Node.js version for using Rocket.Chat is `4.8.4`. Using _n_ we are going to install that version:
 
 ```bash
-sudo n 4.5
+sudo n 4.8.4
 ```
 
 More on [nodejs installation](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-an-ubuntu-14-04-server)

--- a/3. Installation/4. Manual Installation/Windows Server/README.md
+++ b/3. Installation/4. Manual Installation/Windows Server/README.md
@@ -1,7 +1,7 @@
 # Rocket.Chat Windows Installation Guide
-## How to install Rocket.Chat on Windows Server 2012 R2 
+## How to install Rocket.Chat on Windows Server 2012 R2
 
-The following guide will step through the various steps for installing Rocket.Chat on Windows Server 2012 R2. 
+The following guide will step through the various steps for installing Rocket.Chat on Windows Server 2012 R2.
 
 **Important**: Production deployment using any client versions of Windows, such as Windows 7, 8, or 10 is not supported.  However, beta deployment for Windows 10 Pro (or Enterprise or Education) version is available via Docker for Windows see [Installing on Windows 10 Pro 64bit with Docker for Windows](../Windows%2010%20Pro/).
 
@@ -53,11 +53,11 @@ Then, download and install each of the following **in order**:
   > cd [Data Path]
   > mkdir [Data Path]\db
   > mkdir [Data Path]\logs
-  
+
   > cd [Installation Path]\bin
   > mongod.exe --config "[Installation Path]\mongod.cfg" --install
   > net start MongoDB
-  
+
   > mongo.exe
   > rs.initiate()
   > exit
@@ -72,9 +72,9 @@ Then, download and install each of the following **in order**:
 
 ### Node.js
 
-Rocket.Chat is built on top of Node.js v4.5. So we need to install this first.
+Rocket.Chat is built on top of Node.js v4.8.4. So we need to install this first.
 
-1. Download [Node.js v4.5](https://nodejs.org/dist/v4.5.0/node-v4.5.0-x86.msi)
+1. Download [Node.js v4.8.4](https://nodejs.org/dist/v4.8.4/node-v4.8.4-x86.msi)
 2. Run the installer with all default option.
 
 ### Node Packages
@@ -82,7 +82,7 @@ Rocket.Chat is built on top of Node.js v4.5. So we need to install this first.
 1. Open the *Windows SDK 7.1 Command Prompt* by pressing Start, typing its name, and clicking on it in the search results (Note: It needs to be the SDK Command Prompt)
 2. Now enter the following, replacing:
   * [Installation Path] with the location you placed the Rocket.Chat files
-  * [Port to Use] with the port for the Rocket.Chat server to use, such as `3000` 
+  * [Port to Use] with the port for the Rocket.Chat server to use, such as `3000`
   * [Rocket.Chat URL] with the URL you will use for Rocket.Chat, such as `rocketchat.example.com`
   * [Address to MongoDB] with the IP Address of your MongoDB. (NOTE: If you didn't install Mongo on another computer, use `localhost`)
   * [MongoDB Database] with the name of the database you would like to use, such as `rocketchat`
@@ -93,28 +93,28 @@ Rocket.Chat is built on top of Node.js v4.5. So we need to install this first.
   > cd [Installation Path]
   > npm install nave -g
   > npm install node-windows
-  
+
   > npm config set python /Python27/python.exe --global
   > npm config set msvs_version 2010 --global
-  
+
   > set PORT=[Port to Use]
   > set ROOT_URL=[Rocket.Chat URL]
   > set MONGO_URL=mongodb://[Address to Mongo]:27017/[MongoDB Database]
   > set MONGO_OPLOG_URL=mongodb://[Address to Mongo]:27017/local
   > set SCRIPT_PATH=[Installation Path]\main.js
-  
+
   > cd programs\server
   > npm install
-  
+
   > cd ../..
   > node rocket.service.js install
   > net start Rocket.Chat
   ```
-  
+
   Note: If missing, rocket.service.js can be found [here](https://github.com/Sing-Li/bbug/blob/master/images/rocket.service.js)
-  
+
   _Note: Do not include the `>`_
-  
+
 ### Verifying the Install
 
 1. View the installed services by pressing `Windows Key + R` and then entering `services.msc`

--- a/3. Installation/5. Automation Tools/Vagrant/README.md
+++ b/3. Installation/5. Automation Tools/Vagrant/README.md
@@ -77,7 +77,7 @@ Vagrant.configure(2) do |config|
 
     npm install nave -g
     npm install pm2 -g
-    nave usemain 4.5
+    nave usemain 4.8.4
 
     curl https://install.meteor.com/ | sh
 

--- a/3. Installation/7. Updating/1. From 0.x.x to 0.40.0/README.md
+++ b/3. Installation/7. Updating/1. From 0.x.x to 0.40.0/README.md
@@ -1,6 +1,6 @@
 # Upgrading from 0.x.x to 0.40.0
 
-With the release of Rocket.Chat 0.40.0 we are moving from requiring Node.js v0.10.44 to Node.js v4.5 LTS
+With the release of Rocket.Chat 0.40.0 we are moving from requiring Node.js v0.10.44 to Node.js v4.8.4 LTS
 
 If you used docker or one of our cloud installation methods.  Nothing to do, carry on!
 
@@ -8,10 +8,10 @@ If you used docker or one of our cloud installation methods.  Nothing to do, car
 
 First stop Rocket.Chat
 
-The guides suggest the usage of `n` to manage Node.js version.  Assuming that is what you used run:
+The guides suggest the usage of `n` to manage Node.js version. Assuming that is what you used run:
 
 ```
-sudo n 4.5
+sudo n 4.8.4
 ```
 
 Then follow the upgrade steps of your chosen method like normal:


### PR DESCRIPTION
The 4.8.4 version is a security release so proably it's a good idea
to recommend users to install this version instead of 4.5 or other ones

Source: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#4.8.4

closes #373 