### PR TITLE
[FIX] Invalid JSON on Custom Fields example

### DIFF
--- a/6. Developer Guides/Realtime-API/1. Method Calls/01. Register User/README.md
+++ b/6. Developer Guides/Realtime-API/1. Method Calls/01. Register User/README.md
@@ -99,7 +99,7 @@ Example of what we can find inside the `Accounts_CustomFields` **encoded as JSON
             "field": "roles"
         }
     },
-     "twitter": {
+    "twitter": {
         "type": "text",
         "required": true,
         "minLength": 2,


### PR DESCRIPTION
There's a invalid character on the Custom Fields example, causing bug (with no description) to the users that simply copy & paste the example: https://github.com/RocketChat/Rocket.Chat/issues/8448.