### PR TITLE
Improving the getting started guide for new developers 

### DIFF
--- a/1. Contributing/Developing/README.md
+++ b/1. Contributing/Developing/README.md
@@ -7,6 +7,26 @@ we strongly suggest reading GitHub's excellent guide
 
 ## Getting Started
 
+Installing on Linux:
+
+To run Rocket.Chat on windows you must first have the following Prgrams installed
+  - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+  - [Meteor](https://www.meteor.com/install)
+  
+Once the above two prerequistes are installed opened the terminal and run the following:
+
+- git clone https://github.com/RocketChat/Rocket.Chat.git (if you wish to clone your own 
+fork then replace "/RocketChat/" with /YOUR REPOSITORY NAME HERE/)
+- cd Rocket.Chat (Or the name of your repository)
+- meteor npm start (Warning: It may take a while to build so please be patient)
+
+When built you will see a green box within the terminal with "Server Running" at the top.
+This means that a Rocket.Chat server is running from your computer. To access the server
+look within the green box and you will see "Site URL:" here is the web url to access your server.
+If it says http://local.host:3000/ replace "local.host" with your IP address. After this you now
+have access to your server.
+
+
 You can find our projects [here](https://github.com/RocketChat).
 Go to the Issues tab and when you find something you would like to work on
 just comment on it and we will add an [In Progress label][progress_label].

--- a/1. Contributing/Developing/README.md
+++ b/1. Contributing/Developing/README.md
@@ -20,29 +20,19 @@ To run Rocket.Chat on Linux you must first have the following programs installed
   
 Once the above two prerequistes are installed opened the terminal and run the following:
 
-- "git clone https://github.com/RocketChat/Rocket.Chat.git" (if you wish to clone your own 
+- `git clone https://github.com/RocketChat/Rocket.Chat.git` (if you wish to clone your own 
 fork then replace "/RocketChat/" with /YOUR REPOSITORY NAME HERE/)
-- "cd Rocket.Chat" (Or the name of your repository)
-- "meteor npm start" (Warning: It may take a while to build so please be patient)
+- `cd Rocket.Chat` (Or the name of your repository)
+- `meteor npm start` (Warning: It may take a while to build so please be patient)
 
 When built, you will see a green box within the terminal with "Server Running" at the top.
-This means that a Rocket.Chat server is running from your computer. To access the server
-look within the green box and you will see "Site URL:" here is the web url to access your server.
-If it says http://local.host:3000/ replace "local.host" with your IP address. After this you now
-have access to your server.
+This means that a Rocket.Chat server is running from your computer. To access the server navigate to `localhost:3000`
 
 **Editing Rocket.Chat Files:**
 
 Editing files is relatively simple. After you run git clone, the files from the repository are saved on
 your computer. From the directory that it cloned to you can go here to edit or add to Rocket.Chat.
 After you made any changes to Rocket.Chat files just use meteor npm start to attempt to rebuild your changes.
-
-**Pushing Changes to Branch:**
-
-When you have finished making changes to the file and confirmed that it is built, you can go ahead and
-push these changes to the branch on GitHub. From the terminal to push changes:
-
-- Run "git push"
 
 **Where to Find Tasks:**
 

--- a/1. Contributing/Developing/README.md
+++ b/1. Contributing/Developing/README.md
@@ -7,24 +7,37 @@ we strongly suggest reading GitHub's excellent guide
 
 ## Getting Started
 
-Installing on Linux:
+**Installing on Linux:**
 
-To run Rocket.Chat on windows you must first have the following Prgrams installed
+To run Rocket.Chat on Linux you must first have the following programs installed
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
   - [Meteor](https://www.meteor.com/install)
   
 Once the above two prerequistes are installed opened the terminal and run the following:
 
-- git clone https://github.com/RocketChat/Rocket.Chat.git (if you wish to clone your own 
+- "git clone https://github.com/RocketChat/Rocket.Chat.git" (if you wish to clone your own 
 fork then replace "/RocketChat/" with /YOUR REPOSITORY NAME HERE/)
-- cd Rocket.Chat (Or the name of your repository)
-- meteor npm start (Warning: It may take a while to build so please be patient)
+- "cd Rocket.Chat" (Or the name of your repository)
+- "meteor npm start" (Warning: It may take a while to build so please be patient)
 
-When built you will see a green box within the terminal with "Server Running" at the top.
+When built, you will see a green box within the terminal with "Server Running" at the top.
 This means that a Rocket.Chat server is running from your computer. To access the server
 look within the green box and you will see "Site URL:" here is the web url to access your server.
 If it says http://local.host:3000/ replace "local.host" with your IP address. After this you now
 have access to your server.
+
+**Editing Rocket.Chat Files:**
+
+Editing files is relatively simple. After you run git clone, the files from the repository are saved on
+your computer. From the directory that it cloned to you can go here to edit or add to Rocket.Chat.
+After you made any changes to Rocket.Chat files just use meteor npm start to attempt to rebuild your changes.
+
+**Pushing Changes to Branch:**
+
+When you have finished making changes to the file and confirmed that it is built, you can go ahead and
+push these changes to the branch on GitHub. From the terminal to push changes:
+
+- Run "git push"
 
 
 You can find our projects [here](https://github.com/RocketChat).

--- a/1. Contributing/Developing/README.md
+++ b/1. Contributing/Developing/README.md
@@ -5,42 +5,44 @@ If this is the first Open Source project you will contribute to,
 we strongly suggest reading GitHub's excellent guide
 ["Contributing to Open Source"][contributing].
 
-
 ## Getting Started
 
 You can find our projects [here](https://github.com/RocketChat).
 Go to the Issues tab and when you find something you would like to work on
 just comment on it and we will add an [In Progress label][progress_label].
 
-**Installing on Windows:**
+**Developing on Windows:**
 
-To install on Windows please follow [this](https://docs.rocket.chat/installation/manual-installation/windows-server/) guide
+To install on Windows please follow [this](https://docs.rocket.chat/installation/manual-installation/windows-server/) guide.
 
-**Installing on Linux/Mac:**
+**Developing on Linux/Mac:**
 
-To run Rocket.Chat on Linux you must first have the following programs installed
-  - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [Meteor](https://www.meteor.com/install)
-  
-Once the above two prerequistes are installed opened the terminal and run the following:
+To run Rocket.Chat for development on a Linux or a Mac you must first have the following programs installed:
 
-- `git clone https://github.com/RocketChat/Rocket.Chat.git` (if you wish to clone your own 
-fork then replace "/RocketChat/" with /YOUR REPOSITORY NAME HERE/)
-- `cd Rocket.Chat` (Or the name of your repository)
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Meteor](https://www.meteor.com/install)
+
+Once the above two pre-requisites are installed opened the terminal and run the following:
+
+- `git clone https://github.com/RocketChat/Rocket.Chat.git` (if you wish to clone your own fork, replace "/RocketChat/" with /YOUR REPOSITORY NAME HERE/)
+- `cd Rocket.Chat` (or the name of your repository)
 - `meteor npm start` (Warning: It may take a while to build so please be patient)
 
-When built, you will see a green box within the terminal with "Server Running" at the top.
+When the server is ready, you will see a green box within the terminal with "Server Running" at the top.
+
 This means that a Rocket.Chat server is running from your computer. To access the server navigate to `localhost:3000`
 
 **Editing Rocket.Chat Files:**
 
-Editing files is relatively simple. After you run git clone, the files from the repository are saved on
-your computer. From the directory that it cloned to you can go here to edit or add to Rocket.Chat.
-After you made any changes to Rocket.Chat files just use meteor npm start to attempt to rebuild your changes.
+Editing files is relatively simple. After you run `git clone`, the files from the repository are saved on
+your computer. You can go to the cloned repository folder and edit or add files to Rocket.Chat.
+When you make changes to Rocket.Chat the server will automatically rebuild.
+
+Sometimes changes can shut down the server, if that happens just run `meteor npm start` again.
 
 **Where to Find Tasks:**
 
-Want a simple task to get you started?  
+Want a simple task to get you started?
 [We maintain a list of those][easy_label]!
 
 Check our [developer guides](/6.%20Developer%20Guides/)

--- a/1. Contributing/Developing/README.md
+++ b/1. Contributing/Developing/README.md
@@ -5,7 +5,12 @@ If this is the first Open Source project you will contribute to,
 we strongly suggest reading GitHub's excellent guide
 ["Contributing to Open Source"][contributing].
 
+
 ## Getting Started
+
+You can find our projects [here](https://github.com/RocketChat).
+Go to the Issues tab and when you find something you would like to work on
+just comment on it and we will add an [In Progress label][progress_label].
 
 **Installing on Linux:**
 
@@ -39,10 +44,7 @@ push these changes to the branch on GitHub. From the terminal to push changes:
 
 - Run "git push"
 
-
-You can find our projects [here](https://github.com/RocketChat).
-Go to the Issues tab and when you find something you would like to work on
-just comment on it and we will add an [In Progress label][progress_label].
+**Where to Find Tasks:**
 
 Want a simple task to get you started?  
 [We maintain a list of those][easy_label]!

--- a/1. Contributing/Developing/README.md
+++ b/1. Contributing/Developing/README.md
@@ -12,7 +12,11 @@ You can find our projects [here](https://github.com/RocketChat).
 Go to the Issues tab and when you find something you would like to work on
 just comment on it and we will add an [In Progress label][progress_label].
 
-**Installing on Linux:**
+**Installing on Windows:**
+
+To install on Windows please follow [this](https://docs.rocket.chat/installation/manual-installation/windows-server/) guide
+
+**Installing on Linux/Mac:**
 
 To run Rocket.Chat on Linux you must first have the following programs installed
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)


### PR DESCRIPTION
I have improved upon the getting started section within the README file in Rocket.Chat.Docs/1. Contributing/Developing/README.md. Rather than having it just provide a link to where the projects are, I have made it so that it provides a guide for how to run a server on Windows, Mac and Linux. This provides a much more in depth quick start guide and allows for new developers to have an easier time getting started. 