### PR TITLE
Change `AutoSSl` to `AutoSSL`.

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -45,7 +45,7 @@
     - RedHat
     - Ubuntu:
       - Snaps:
-        - AutoSSl
+        - AutoSSL
     - Windows 10 Pro
     - Windows Server:
       - Releases


### PR DESCRIPTION
Just noticed the tree menu item should be `AutoSSL`:

![capture](https://user-images.githubusercontent.com/8067797/34884819-f180b03e-f78b-11e7-9109-48618e7b94ce.PNG)

