### PR TITLE
Hard code canonical address

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   <script src="{{ site.url }}/public/js/sidebar.min.js"></script>
 
-  <link rel="canonical" href="{{site.url}}{{page.url}}">
+  <link rel="canonical" href="https://rocket.chat/docs{{page.url}}">
   <link rel="shortcut icon" href="/favicon.ico?v=1"/>
 </head>
 


### PR DESCRIPTION
Prevent Jekyll and GitHub pages from using rocketchat.github.io domain