### PR TITLE
Fix absolute link to relative

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -4,11 +4,11 @@
   description: Guides for the basic usage of Rocket.Chat.
   path: user-guides/
   pages:
-    Connecting to a Server: /user-guides/connecting-to-a-server/
-    Registration: /user-guides/registration/
-    Channels: /user-guides/channels/
-    Messaging: /user-guides/messaging/
-    Managing your Account: /user-guides/managing-your-account/
+    Connecting to a Server: /connecting-to-a-server/
+    Registration: /registration/
+    Channels: /channels/
+    Messaging: /messaging/
+    Managing your Account: /managing-your-account/
 
 -
   name: Rocket.Chat Administrator Guides
@@ -16,12 +16,12 @@
   description: Guides for managing and configuring Rocket.Chat
   path: administrator-guides/
   pages:
-    Account Settings: /administrator-guides/account-settings/
-    Email: /administrator-guides/email/
-    Permissions: /administrator-guides/permissions/
-    Livechat: /administrator-guides/livechat/
-    File Upload: /administrator-guides/file-upload/
-    Integrations: /administrator-guides/integrations/
+    Account Settings: /account-settings/
+    Email: /email/
+    Permissions: /permissions/
+    Livechat: /livechat/
+    File Upload: /file-upload/
+    Integrations: /integrations/
 
 -
   name: Rocket.Chat Developer Guides
@@ -29,12 +29,12 @@
   description: Guides for developing and modifying Rocket.Chat's code
   path: developer-guides/
   pages:
-    Quick Start: /developer-guides/quick-start/
-    Branches and Releases: /developer-guides/branches-and-releases/
-    Testing: /developer-guides/testing/
-    Rest API: /developer-guides/rest-api/
-    Realtime API: /developer-guides/realtime-api/
-    Livechat API: /developer-guides/livechat-api/
+    Quick Start: /quick-start/
+    Branches and Releases: /branches-and-releases/
+    Testing: /testing/
+    Rest API: /rest-api/
+    Realtime API: /realtime-api/
+    Livechat API: /livechat-api/
 
 -
   name: Rocket.Chat Android

--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -9,7 +9,7 @@
 				</div>
 				<div class="card-pages">
 					{% for page in project.pages %}
-						<a href="{{ page[1] }}">{{ page[0] }}</a>
+						<a href="{{ project.path }}{{ page[1] }}">{{ page[0] }}</a>
 					{% endfor %}
 					{% capture http %}{{ project.path | truncate: 4, '' }}{% endcapture %}
 					{% if http == 'http' %}


### PR DESCRIPTION
Using absolute links only works when serving from local.  Production uses /docs/ so links need to be relative.

ref #577