### PR TITLE
Document a more secure CORS policy.

### DIFF
--- a/administrator-guides/file-upload/amazon-s3/README.md
+++ b/administrator-guides/file-upload/amazon-s3/README.md
@@ -6,7 +6,7 @@ You'll need to set the following _CORS Configuration_ to your bucket:
 <?xml version="1.0" encoding="UTF-8"?>
 <CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
     <CORSRule>
-        <AllowedOrigin>*</AllowedOrigin>
+        <AllowedOrigin>{{ROCKET_CHAT_DOMAIN}}</AllowedOrigin>
         <AllowedMethod>PUT</AllowedMethod>
         <AllowedMethod>POST</AllowedMethod>
         <AllowedMethod>GET</AllowedMethod>
@@ -16,6 +16,8 @@ You'll need to set the following _CORS Configuration_ to your bucket:
     </CORSRule>
 </CORSConfiguration>
 ```
+
+**Important**: Replace `{{ROCKET_CHAT_DOMAIN}}` with the domain of your Rocket Chat installation, e.g. `https://chat.example.com`. If for some reason you want to make your CORS configuration ridiculously insecure, you can set it to `*` to allow CORS requests from any host on the Internet, but do so at your own risk.
 
 ## Basic configuration
 


### PR DESCRIPTION
Don't recommend users to use wildcard origins in CORS policies.