### PR TITLE
[FIX] Fix CURL command in REST authentication endpoint

### DIFF
--- a/developer-guides/rest-api/authentication/facebook/README.md
+++ b/developer-guides/rest-api/authentication/facebook/README.md
@@ -19,7 +19,7 @@
 ```bash
 curl -H "Content-type:application/json" \
       http://localhost:3000/api/v1/login \
-      -d '{ "serviceName": "facebook", accessToken": "hash",
+      -d '{ "serviceName": "facebook", "accessToken": "hash",
       "secret": "hash", "expiresIn": 200 }'
 ```
 

--- a/developer-guides/rest-api/authentication/google/README.md
+++ b/developer-guides/rest-api/authentication/google/README.md
@@ -20,7 +20,7 @@
 ```bash
 curl -H "Content-type:application/json" \
       http://localhost:3000/api/v1/login \
-      -d '{ "serviceName": "google", accessToken": "hash",
+      -d '{ "serviceName": "google", "accessToken": "hash",
       "idToken": "hash", "expiresIn": 200, "scope": "profile" }'
 ```
 

--- a/developer-guides/rest-api/authentication/twitter/README.md
+++ b/developer-guides/rest-api/authentication/twitter/README.md
@@ -21,7 +21,7 @@
 ```bash
 curl -H "Content-type:application/json" \
       http://localhost:3000/api/v1/login \
-      -d '{ "serviceName": "twitter", accessToken": "hash", accessTokenSecret: "hash",
+      -d '{ "serviceName": "twitter", "accessToken": "hash", accessTokenSecret: "hash",
       "appSecret": "hash", "appId": "hash", "expiresIn": 200}'
 ```
 


### PR DESCRIPTION
Fix CURL command that was missing a quote at the beginning of "accessToken" property in REST authentication endpoint.
Refs: https://github.com/RocketChat/Rocket.Chat/issues/10307, https://github.com/RocketChat/Rocket.Chat/issues/10389