### PR TITLE
Docs: Pipe breaks page display

### DIFF
--- a/administrator-guides/file-upload/README.md
+++ b/administrator-guides/file-upload/README.md
@@ -4,7 +4,7 @@ There are several choices for file Storage
 
 - GridFS
 - [Amazon S3](amazon-s3/)
-- [Minio | selfhosted s3 compatible object storage](minio/)
+- [Minio - selfhosted s3 compatible object storage](minio/)
 - Local file system
 
 To change the system that you want to use from the default GridFS select the option from the "Storage Type" section.


### PR DESCRIPTION
While valid markup, the inclusion of the pipe character is breaking display on [the Rocket.Chat site](https://rocket.chat/docs/administrator-guides/file-upload/) and rendering the Minio section in its own table.