### PR TITLE
Fix Documentation: Add missing rewrite mod to Apache installation

### DIFF
--- a/installation/manual-installation/configuring-ssl-reverse-proxy/README.md
+++ b/installation/manual-installation/configuring-ssl-reverse-proxy/README.md
@@ -96,6 +96,7 @@ a2enmod proxy_http
 a2enmod proxy
 a2enmod ssl
 a2enmod proxy_wstunnel
+a2enmod rewrite
 ```
 
 Add your private key to ```/etc/ssl/private/chat.domain.com.key```


### PR DESCRIPTION
The Apache install instructions were missing the required `rewrite` mod.