### PR TITLE
[FIX] Improve general styling 

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,18 +76,21 @@
                 <span>Contribute to this page on GitHub</span>
               </a>
             </div>
-            <div id='discourse-comments'></div>
 
-              <script type="text/javascript">
-                    DiscourseEmbed = { discourseUrl: 'https://forums.rocket.chat/',
-                                      discourseEmbedUrl: location.toString() };
+            {%if site.url == "rocket.chat"%}
+              <div id='discourse-comments'></div>
 
-                    (function() {
-                      var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
-                      d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
-                      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
-                    })();
-            </script>
+                <script type="text/javascript">
+                      DiscourseEmbed = { discourseUrl: 'https://forums.rocket.chat/',
+                                        discourseEmbedUrl: location.toString() };
+
+                      (function() {
+                        var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+                        d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+                        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+                      })();
+              </script>
+            {%endif%}
           </div>
           <div class="article-toc-wrapper">
             {% include article-toc.html html=content sanitize=true class="inline_toc" id="my_toc" h_min=2 h_max=3 %}

--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -88,6 +88,7 @@
 
     a {
       display: inline-flex;
+      font-size: 1em;
       transition: color 0.3s ease;
     }
 

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -34,26 +34,30 @@ body {
   h4,
   h5 {
     line-height: 1.28571429em;
-    margin: calc(2rem -  0.14285714em ) 0em 1rem;
+    margin-bottom: 14px;
     font-weight: bold;
     padding: 0em;
     display: flex;
   }
   h1 {
-    min-height: 1rem;
-    font-size: 2rem;
+    min-height: 1em;
+    font-size: 2em;
+    margin-bottom: 24px;
   }
   h2 {
-    font-size: 1.71428571rem;
+    font-size: 1.71428571em;
+    margin-bottom: 24px;
+    margin-top: 24px;
   }
   h3 {
-    font-size: 1.28571429rem;
+    font-size: 1.28571429em;
+    margin-bottom: 16px;
   }
   h4 {
-    font-size: 1.07142857rem;
+    font-size: 1.07142857em;
   }
   h5 {
-    font-size: 1rem;
+    font-size: 1em;
   }
   h1:first-child,
   h2:first-child,
@@ -289,7 +293,7 @@ main {
   width: $toc-width;
   overflow-y: auto;
   padding:  1em 1em 1em 0;
-  font-size: 0.9em;
+  font-size: 14px;
 
   li {
     font-weight: normal;
@@ -332,6 +336,7 @@ main {
   border-left: 1px solid #ddd;
 
   .wrapper {
+    font-size: 14px;
     padding-right: 1em;
   }
 }
@@ -452,7 +457,7 @@ td > code {
 .content table {
   display: table;
   width: 100%;
-  margin: 1rem auto;
+  margin: 1em auto;
   border-top: 1px solid #bfbfbf;
   border-collapse: collapse;
   border-spacing: 0;
@@ -586,7 +591,8 @@ td > code {
   order: 2;
   margin: 0 10px;
   img {
-    width: 20px;
+    width: 15px;
+    height: 15px;
   }
 }
 
@@ -596,4 +602,5 @@ h4:hover .header-link,
 h5:hover .header-link,
 h6:hover .header-link {
   display: flex;
+  align-items: center;
 }

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -132,7 +132,7 @@ blockquote {
   color: $space;
   background-color: $grey-bg;
   border: 1px solid $grey-smoke;
-  margin: 2em 1em;
+  margin: 2em 0;
   padding: 15px;
   border-radius: 2px;
 }
@@ -145,7 +145,6 @@ blockquote {
 
   &.main {
     display: flex;
-    padding-right: 0.5em;
   }
 
   &.home{
@@ -346,12 +345,16 @@ main {
 }
 
 .article-toc-wrapper{
-  width: 35%;
+  width: 30%;
   height: fit-content;
   padding-left: 0.5em;
   border-left: 1px solid #ddd;
   h4:last-child {
     display: none;
+  }
+  .inline_toc {
+    font-size: 13px;
+    font-weight: 500;
   }
 }
 

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -73,7 +73,7 @@ strong {
 }
 
 .label--small {
-  font-size: 0.6rem;
+  font-size: 0.6em;
   line-height: 1.6;
   letter-spacing: 0.5px;
   text-transform: uppercase;

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -1,7 +1,6 @@
 body,
 input,
-button,
-pre {
+button {
   font-size: $font-size;
   font-family: $font-family;
   color: $grey;

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -1,7 +1,6 @@
 $content-width: 1125px;
 
 $line-height: 1.58;
-$font-size: 16px;
 
 $color-primary: #1d74f5;
 $color-secondary: #c1272d;
@@ -11,7 +10,7 @@ $color-light: #929db3;
 
 $padding: 2em;
 
-$toc-width: 280px;
+$toc-width: 240px;
 
 // 1. Fonts
 $font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,


### PR DESCRIPTION
This pull request improves spacing, fonts and space usage in general, this makes the docs easier to read.

This also fix the anchor links moving other elements and hides the comment section on non `rocket.chat` locations (like hosting on localhost or someone else github pages).

More improvements are bound to come soon as the new designs are being created.

Before:
![screen shot 2018-06-07 at 15 34 34](https://user-images.githubusercontent.com/20868078/41119483-4a0c0c3a-6a69-11e8-8803-f8ac5d8ac7f3.png)

After: 
![screen shot 2018-06-07 at 15 34 31](https://user-images.githubusercontent.com/20868078/41119520-5c28707a-6a69-11e8-9812-33a33864a488.png)

