### PR TITLE
Fix different color hovers on toc and article-toc

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -312,6 +312,11 @@ main {
     color: $color-dark;
   }
 
+  a:hover {
+    color: #1e70bf;
+    text-decoration: none;
+  }
+
   ul {
     list-style: none;
     margin: 0 0 0 20px;
@@ -360,6 +365,15 @@ main {
   .inline_toc {
     font-size: 13px;
     font-weight: 500;
+
+    a, a:visited {
+      color: $color-dark;
+    }
+
+    a:hover {
+      color: #1e70bf;
+      text-decoration: none;
+    }
   }
 }
 


### PR DESCRIPTION
Some links on the toc were getting the color black on hoover, this fixes that and syncs the toc and article-toc colors