### PR TITLE
Update hubot image and bot account creation.

### DIFF
--- a/installation/docker-containers/README.md
+++ b/installation/docker-containers/README.md
@@ -455,10 +455,9 @@ No worries! In order to get your bot up and running, we must register it…
 
 ## 9. Registering & Configuring Hubot, the chat robot
 
-Previously, we created the docker-compose.yml file. It's this file where we defined the basic attributes for Hubot. We set the bot name, password, room to join, and scripts to run. Before the bot can join the chat room, we must manually create the bot using the configuration details we provided in docker-compose.yml. 
+Previously, we created the docker-compose.yml file. It's this file where we defined the basic attributes for Hubot. We set the bot name, password, room to join, and scripts to run. Before the bot can join the chat room, we must manually create the bot using the configuration details we provided in docker-compose.yml.
 
-[https://github.com/RocketChat/hubot-rocketchat#creating-a-user-on-the-server]
-
+<https://github.com/RocketChat/hubot-rocketchat#creating-a-user-on-the-server>
 
 You can now optionally login and set some of the preferences, such as bot avatar. When finished, log out of the bot account.
 

--- a/installation/docker-containers/README.md
+++ b/installation/docker-containers/README.md
@@ -310,7 +310,7 @@ rocketchat:
     - 3000:3000
 
 hubot:
-  image: rocketchat/hubot-rocketchat:v0.1.4
+  image: rocketchat/hubot-rocketchat:latest
   environment:
     - ROCKETCHAT_URL=165.114.165.21:3000
     - ROCKETCHAT_ROOM=GENERAL
@@ -455,19 +455,14 @@ No worries! In order to get your bot up and running, we must register it…
 
 ## 9. Registering & Configuring Hubot, the chat robot
 
-Previously, we created the docker-compose.yml file. It's this file where we defined the basic attributes for Hubot. We set the bot name, password, room to join, and scripts to run. Before the bot can join the chat room, we must manually register the bot using the configuration details we provided in docker-compose.yml. Log out, if you're logged in to the chat room.
+Previously, we created the docker-compose.yml file. It's this file where we defined the basic attributes for Hubot. We set the bot name, password, room to join, and scripts to run. Before the bot can join the chat room, we must manually create the bot using the configuration details we provided in docker-compose.yml. 
 
-Browse to the chat room login page, and click the link to register a new account. This time, you must register an account for your bot to use.
+[https://github.com/RocketChat/hubot-rocketchat#creating-a-user-on-the-server]
 
-Name: use the value you specified for ROCKETCHAT_USER
-Email: if you plan to enable new account email verification, be sure to use a valid email here
-Password:  use the value you specified for ROCKETCHAT_PASSWORD
 
-When prompted in the next screen to specify a name for @ mentions, use the value you specified for BOT_NAME.
+You can now optionally login and set some of the preferences, such as bot avatar. When finished, log out of the bot account.
 
-Once you're logged in with the new bot account, you can go ahead and set some of the preferences, such as bot avatar. When finished, log out of the bot account.
-
-With the bot account registered, you can force it to join by simply rebooting the server, upon which the init script should automatically launch your chat room, and the bot should join the “General” room.
+With the bot account created, you can force it to join by simply rebooting the server, upon which the init script should automatically launch your chat room, and the bot should join the “General” room.
 
 For basic command help, in the chat message box, type BOTNAME help (where BOTNAME is your bot's name).
 


### PR DESCRIPTION
Use latest hubot image as 0.1.4 won't work with the current versions of Rocket.Chat.
Use docs from RocketChat/hubot-rocketchat from bot account creation.