### PR TITLE
Facebook strict mode for redirect urls

### DIFF
--- a/administrator-guides/authentication/oauth/README.md
+++ b/administrator-guides/authentication/oauth/README.md
@@ -6,7 +6,7 @@ These settings are in the `Accounts` setting page under `Administration`.
 
 ## Facebook
 
-- Callback url: `<<website_url>>/_oauth/facebook`
+- Callback url: `<<website_url>>/_oauth/facebook?close`
 
 ## GitHub
 


### PR DESCRIPTION
Facebook now enforces strict mode for redirect urls, <<website_url>>/_oauth/facebook?close is now the proper format.
Fixes https://github.com/RocketChat/Rocket.Chat/issues/11389