### PR TITLE
Fix Documentation: Authentication Guide

### DIFF
--- a/developer-guides/rest-api/authentication/logout/README.md
+++ b/developer-guides/rest-api/authentication/logout/README.md
@@ -2,7 +2,7 @@
 
 | URL | Requires Auth | HTTP Method |
 | :--- | :--- | :--- | :--- |
-| `/api/v1/logout` | `yes` | `GET` |
+| `/api/v1/logout` | `yes` | `POST` |
 
 ## Example Call
 


### PR DESCRIPTION
Logging out by `GET` is deprecated (`Warning: Default logout via GET will be removed in Restivus v1.0. Use POST instead.`).