### PR TITLE
Adding Graylog alerts integration for Rocket.Chat

### DIFF
--- a/administrator-guides/integrations/graylog/README.md
+++ b/administrator-guides/integrations/graylog/README.md
@@ -1,0 +1,7 @@
+# Graylog
+
+[Graylog](https://graylog.org) is a powerful open-source log management platform. It aggregates and extracts important data from server logs, which are often sent using the Syslog protocol. It also allows you to search and visualize the logs in a web interface.
+
+Follow the install instructions here:
+
+<https://github.com/jeanmorais/rocketchat-graylog-hook>


### PR DESCRIPTION
Graylog provides an integration via HTTP for alert notifications. To receive the Graylog events in our channels, I decide to perform this integration.

Example alert notification:

![Example alert notification](https://raw.githubusercontent.com/jeanmorais/rocketchat-graylog-hook/master/screenshots/screenshot1.PNG)