### PR TITLE
Add others way to install nodes and autostart rocketchat service

### DIFF
--- a/installation/manual-installation/centos/README.md
+++ b/installation/manual-installation/centos/README.md
@@ -51,6 +51,15 @@ The recommended Node.js version for using Rocket.Chat is `8.9.3`. Using _n_ we a
 n 8.9.3
 ```
 
+**HELP**
+
+There is also a way to install nodejs：
+
+```
+curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
+yum -y install nodejs
+```
+
 ## Installing Rocket.Chat
 
 Now we download and install Rocket.Chat
@@ -172,6 +181,52 @@ And finally start it by running:
 
 ```
 systemctl start rocketchat.service
+```
+
+**HELP**
+
+There is also a way to autostart rocketchat:
+
+* Install supervisor service
+
+```
+yum install supervisor
+```
+
+* Write a startup script, `vim /opt/Rocket.Chat/start.sh`
+
+```
+#/bin/bash
+cd /opt/Rocket.Chat/
+export PORT=3000
+export ROOT_URL=http://your-host-name.com-as-accessed-from-internet:3000/
+export MONGO_URL=mongodb://localhost:27017/rocketchat
+node /opt/Rocket.Chat/main.js
+```
+* Give script execution permission
+
+```
+chmod +x /opt/Rocket.Chat/start.sh
+```
+
+* Configuration supervisor
+
+```
+[program:rocketchat]
+command=bash /opt/Rocket.Chat/start.sh
+directory=/opt/Rocket.Chat
+autostart=true
+autorestart=true
+logfile=/var/log/supervisor/rocketchat.log
+log_stderr=true
+user=root
+```
+
+* Start service
+
+```
+service supervisord start 
+chkconfig supervisord on
 ```
 
 ### Upgrade

--- a/installation/manual-installation/centos/README.md
+++ b/installation/manual-installation/centos/README.md
@@ -193,7 +193,7 @@ Install supervisor service
 yum install supervisor
 ```
 
-Write a startup script, 
+Write a startup script
 
 ```
 vim /opt/Rocket.Chat/start.sh
@@ -209,6 +209,7 @@ export ROOT_URL=http://your-host-name.com-as-accessed-from-internet:3000/
 export MONGO_URL=mongodb://localhost:27017/rocketchat
 node /opt/Rocket.Chat/main.js
 ```
+
 Give script execution permission
 
 ```
@@ -231,7 +232,7 @@ user=root
 Start service
 
 ```
-service supervisord start 
+service supervisord start
 chkconfig supervisord on
 ```
 

--- a/installation/manual-installation/centos/README.md
+++ b/installation/manual-installation/centos/README.md
@@ -51,7 +51,7 @@ The recommended Node.js version for using Rocket.Chat is `8.9.3`. Using _n_ we a
 n 8.9.3
 ```
 
-**HELP**
+**Other Way**
 
 There is also a way to install nodejs：
 
@@ -183,17 +183,23 @@ And finally start it by running:
 systemctl start rocketchat.service
 ```
 
-**HELP**
+**Other Way**
 
 There is also a way to autostart rocketchat:
 
-* Install supervisor service
+Install supervisor service
 
 ```
 yum install supervisor
 ```
 
-* Write a startup script, `vim /opt/Rocket.Chat/start.sh`
+Write a startup script, 
+
+```
+vim /opt/Rocket.Chat/start.sh
+```
+
+Copy this to start.sh
 
 ```
 #/bin/bash
@@ -203,13 +209,13 @@ export ROOT_URL=http://your-host-name.com-as-accessed-from-internet:3000/
 export MONGO_URL=mongodb://localhost:27017/rocketchat
 node /opt/Rocket.Chat/main.js
 ```
-* Give script execution permission
+Give script execution permission
 
 ```
 chmod +x /opt/Rocket.Chat/start.sh
 ```
 
-* Configuration supervisor
+Configuration supervisor
 
 ```
 [program:rocketchat]
@@ -222,7 +228,7 @@ log_stderr=true
 user=root
 ```
 
-* Start service
+Start service
 
 ```
 service supervisord start 


### PR DESCRIPTION
Add others way to install nodes and autostart rocket chat service, I used yum mirror install the nodes,simplified the related steps, but the results are the same。