### PR TITLE
Make format of SAML Cert and Key more clear

### DIFF
--- a/administrator-guides/authentication/saml/README.md
+++ b/administrator-guides/authentication/saml/README.md
@@ -30,9 +30,12 @@ This is the idp providers public certificate that is used to verify the SAML req
 
 The public part of the self-signed certificate you created for encrypting your SAML transactions. [Example of self-signed certificate on the SimpleSAMLphp website here.](https://simplesamlphp.org/docs/stable/simplesamlphp-sp#section_1_1)
 
+Format for this is PEM WITH `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
+
 ### Private Key Contents (SP Signing Private Key)
 
 The private key matching the self-signed certificate you created as PKCS#1 PEM.
+Format for this is PEM WITH `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----`.
 
 ### SAML assertion
 


### PR DESCRIPTION
I just setup rocket.chat with SAML and fell for this hole. Seems that others have hit this wall as well.

https://github.com/RocketChat/Rocket.Chat/issues/9634
https://github.com/RocketChat/Rocket.Chat/issues/6317

Please commit this change to make it more visible how to use the data.
Thanks
Philipp