### PR TITLE
Update README.md

### DIFF
--- a/installation/manual-installation/centos/README.md
+++ b/installation/manual-installation/centos/README.md
@@ -39,7 +39,7 @@ curl -L https://releases.rocket.chat/latest/download -o /tmp/rocket.chat.tgz
 ```
 
 ```
-tar -xzf /tmp/rocket.chat.tgz -C /tmp && mv /tmp/bundle /tmp/Rocket.Chat
+tar -xzf /tmp/rocket.chat.tgz -C /tmp
 ```
 
 Install (this tutorial uses /opt but change it as convenience):


### PR DESCRIPTION
The tar extract instruction does mv /tmp/bundle /tmp/Rocket.Chat and then cd /tmp/bundle/programs/server which is to a directory that then no longer exists.

Updated to match the correct instruction from the Debian Manual Install doc.