### PR TITLE
Document chat.ignoreUser API endpoint

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -301,6 +301,7 @@
         - unPinMessage
         - unStarMessage
         - update
+        - ignoreUser
       - Commands:
         - get
         - list

--- a/contributing/documentation/documentation-map/README.md
+++ b/contributing/documentation/documentation-map/README.md
@@ -312,6 +312,7 @@ Here you can also find what articles are incomplete and missing.
             - unPinMessage
             - unStarMessage
             - update
+            - ignoreUser
         - Commands:
             - get
             - list

--- a/developer-guides/rest-api/README.md
+++ b/developer-guides/rest-api/README.md
@@ -166,6 +166,7 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | `/api/v1/chat.unStarMessage`          | Removes the star on the chat message for the authenticated user. | [Link](chat/unstarmessage/)             |
 | `/api/v1/chat.update`                 | Updates the text of the chat message.                            | [Link](chat/update/)                    |
 | `/api/v1/chat.getMessageReadReceipts` | Retrieves message read receipts.                                 | [Link](chat/getmessagereadreceipts/)    |
+| `/api/v1/chat.ignoreUser`             | Ignores an user from a chat.                                     | [Link](chat/ignoreuser/)                |
 
 ### IM
 

--- a/developer-guides/rest-api/README.md
+++ b/developer-guides/rest-api/README.md
@@ -155,6 +155,8 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | `/api/v1/chat.delete`                 | Deletes an existing chat message.                                | [Link](chat/delete/)                    |
 | `/api/v1/chat.getDeletedMessages`     | Retrieves the deleted messages since specific date.              | [Link](chat/getdeletedmessages/)        |
 | `/api/v1/chat.getMessage`             | Retrieves a single chat message.                                 | [Link](chat/getmessage/)                |
+| `/api/v1/chat.getMessageReadReceipts` | Retrieves message read receipts.                                 | [Link](chat/getmessagereadreceipts/)    |
+| `/api/v1/chat.ignoreUser`             | Ignores an user from a chat.                                     | [Link](chat/ignoreuser/)                |
 | `/api/v1/chat.pinMessage`             | Pins a chat message to the message's channel.                    | [Link](chat/pinmessage/)                |
 | `/api/v1/chat.postMessage`            | Posts a new chat message.                                        | [Link](chat/postmessage/)               |
 | `/api/v1/chat.react`                  | Sets/unsets the user's reaction to an existing chat message.     | [Link](chat/react/)                     |
@@ -165,8 +167,6 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | `/api/v1/chat.unPinMessage`           | Removes the pinned status of the provided chat message.          | [Link](chat/unpinmessage/)              |
 | `/api/v1/chat.unStarMessage`          | Removes the star on the chat message for the authenticated user. | [Link](chat/unstarmessage/)             |
 | `/api/v1/chat.update`                 | Updates the text of the chat message.                            | [Link](chat/update/)                    |
-| `/api/v1/chat.getMessageReadReceipts` | Retrieves message read receipts.                                 | [Link](chat/getmessagereadreceipts/)    |
-| `/api/v1/chat.ignoreUser`             | Ignores an user from a chat.                                     | [Link](chat/ignoreuser/)                |
 
 ### IM
 

--- a/developer-guides/rest-api/chat/README.md
+++ b/developer-guides/rest-api/chat/README.md
@@ -5,6 +5,8 @@
 | `/api/v1/chat.delete` | Deletes an existing chat message. | [Link](delete/) |
 | `/api/v1/chat.getDeletedMessages`  | Retrieves the deleted messages since specific date.  | [Link](getdeletedmessages/) |
 | `/api/v1/chat.getMessage` | Retrieves a single chat message. | [Link](getmessage/) |
+| `/api/v1/chat.getMessageReadReceipts` | Retrieves message read receipts. | [Link](getmessagereadreceipts/) |
+| `/api/v1/chat.ignoreUser` | Ignores an user from a chat. | [Link](ignoreuser/) |
 | `/api/v1/chat.pinMessage` | Pins a chat message to the message's channel. | [Link](pinmessage/) |
 | `/api/v1/chat.postMessage` | Posts a new chat message. | [Link](postmessage/) |
 | `/api/v1/chat.react` | Sets/unsets the user's reaction to an existing chat message. | [Link](react/) |
@@ -15,5 +17,3 @@
 | `/api/v1/chat.unPinMessage` | Removes the pinned status of the provided chat message. | [Link](unpinmessage/) |
 | `/api/v1/chat.unStarMessage` | Removes the star on the chat message for the authenticated user. | [Link](unstarmessage/) |
 | `/api/v1/chat.update` | Updates the text of the chat message. | [Link](update/) |
-| `/api/v1/chat.getMessageReadReceipts` | Retrieves message read receipts. | [Link](getmessagereadreceipts/) |
-| `/api/v1/chat.ignoreUser` | Ignores an user from a chat. | [Link](ignoreuser/) |

--- a/developer-guides/rest-api/chat/README.md
+++ b/developer-guides/rest-api/chat/README.md
@@ -16,3 +16,4 @@
 | `/api/v1/chat.unStarMessage` | Removes the star on the chat message for the authenticated user. | [Link](unstarmessage/) |
 | `/api/v1/chat.update` | Updates the text of the chat message. | [Link](update/) |
 | `/api/v1/chat.getMessageReadReceipts` | Retrieves message read receipts. | [Link](getmessagereadreceipts/) |
+| `/api/v1/chat.ignoreUser` | Ignores an user from a chat. | [Link](ignoreuser/) |

--- a/developer-guides/rest-api/chat/ignoreuser/README.md
+++ b/developer-guides/rest-api/chat/ignoreuser/README.md
@@ -1,0 +1,37 @@
+# Ignore user
+
+Ignores an user in a chat.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/chat.ignoreUser` | `yes` | `GET` |
+
+## Payload
+
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `rid` | `KLTM332QEwWLPJrjRPtcPHimPnLHsusiDF` | Required | The room ID. |
+| `userId` | `7aDSXtjMA3KPLxLjt` | Required | The User ID. |
+
+## Example Call
+
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type:application/json" \
+     http://localhost:3000/api/v1/chat.ignoreUser?rid=KLTM332QEwWLPJrjRPtcPHimPnLHsusiDF&userId=7aDSXtjMA3KPLxLjt
+```
+
+## Example Result
+
+```json
+{
+    "success": true
+}
+```
+
+## Change Log
+
+| Version | Description |
+| :--- | :--- |
+|  | Added |

--- a/developer-guides/rest-api/chat/ignoreuser/README.md
+++ b/developer-guides/rest-api/chat/ignoreuser/README.md
@@ -1,6 +1,6 @@
 # Ignore user
 
-Ignores an user in a chat.
+Ignores an user in a chat. If you pass ignore as false, the user will be unignored.
 
 | URL | Requires Auth | HTTP Method |
 | :--- | :--- | :--- |
@@ -12,6 +12,7 @@ Ignores an user in a chat.
 | :--- | :--- | :--- | :--- |
 | `rid` | `KLTM332QEwWLPJrjRPtcPHimPnLHsusiDF` | Required | The room ID. |
 | `userId` | `7aDSXtjMA3KPLxLjt` | Required | The User ID. |
+| `ignore` | `true` | Optional | If the user will be ignored or not, default is true. |
 
 ## Example Call
 
@@ -20,6 +21,20 @@ curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
      -H "X-User-Id: aobEdbYhXfu5hkeqG" \
      -H "Content-type:application/json" \
      http://localhost:3000/api/v1/chat.ignoreUser?rid=KLTM332QEwWLPJrjRPtcPHimPnLHsusiDF&userId=7aDSXtjMA3KPLxLjt
+```
+
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type:application/json" \
+     http://localhost:3000/api/v1/chat.ignoreUser?rid=KLTM332QEwWLPJrjRPtcPHimPnLHsusiDF&ignore=true
+```
+
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     -H "Content-type:application/json" \
+     http://localhost:3000/api/v1/chat.ignoreUser?rid=KLTM332QEwWLPJrjRPtcPHimPnLHsusiDF&ignore=false
 ```
 
 ## Example Result
@@ -34,4 +49,4 @@ curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
 
 | Version | Description |
 | :--- | :--- |
-|  | Added |
+| 0.64.0 | Added |


### PR DESCRIPTION
Add `chat.ignoreUser` endpoint documentation. 

I couldn't find which version this endpoint was added, can someone help me with this? 