### PR TITLE
GraphQL - Enhance docs about setup (especially secured WebSocket connection)

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -186,6 +186,11 @@
       - Supported Servers Versions
     - Developing Apps:
       - Getting Started
+    - GraphQL API:
+       - Authentication
+       - Schema
+       - Setup
+       - Subscription
     - Realtime-API:
       - Method Calls:
         - Login

--- a/contributing/documentation/documentation-map/README.md
+++ b/contributing/documentation/documentation-map/README.md
@@ -199,6 +199,11 @@ Here you can also find what articles are incomplete and missing.
     - Mobile Apps
         - Supporting SSL
         - Supported Servers Versions
+    - GraphQL API:
+        - Authentication
+        - Schema
+        - Setup
+        - Subscription
     - Realtime-API:
         - Method Calls:
             - Login

--- a/developer-guides/graphql-api/README.md
+++ b/developer-guides/graphql-api/README.md
@@ -3,11 +3,9 @@
 Rocket.Chat now supports a GraphQL API.
 > **This API is a work in progress, so feel free to test, ask us questions, and submit Pull Requests!**
 
-The administrator must enable the GraphQL API in the admin panel (`General` -> `GraphQL API`).
-After that, you are able to use the GraphQL API, under `/api/graphql` endpoint.
-
 Here are some links that will be useful for the use of Rocket.Chat GraphQL API
 
+[Setup](setup/) <br/>
 [Authentication](authentication/) <br/>
 [Schema](schema/) <br/>
 [Subscription](subscription/)

--- a/developer-guides/graphql-api/setup/README.md
+++ b/developer-guides/graphql-api/setup/README.md
@@ -19,13 +19,13 @@ GraphiQL is available under `/graphiql` in your browser.
 A WebSocket connection can be used for communicating with GraphQL.
 One example would be the `chatMessageAdded` event (subscriptions).
 
-By default, this WebSocket connection can be established in unsecured mode, only (`ws://`). If you want to use the 
+By default, this WebSocket connection can be established in unsecured mode, only (`ws://`). If you want to use the
 secured version (`wss://`), there's a slight modification to be made:
 
-Currently, there's no way of connecting **directly** to the secured WebSocket. So you'll need to set up a kind of 
+Currently, there's no way of connecting **directly** to the secured WebSocket. So you'll need to set up a kind of
 reverse proxy, that takes a standard HTTP connection and upgrades it to a WebSocket.
 
-For example, for the nginx webserver, it could look like this: 
+For example, for the nginx webserver, it could look like this:
 
 ```
 server {

--- a/developer-guides/graphql-api/setup/README.md
+++ b/developer-guides/graphql-api/setup/README.md
@@ -1,0 +1,49 @@
+# GraphQL API Setup
+
+## General information
+
+In order to be able to use the GraphQL API, this feature has to be enabled by the administrator. In the admin panel,
+check `General` -> `GraphQL API`.
+
+After that, you are able to use the GraphQL API, under `/api/graphql` endpoint.
+
+## First steps
+
+For convenience, Rocket.Chat is shipped with a tool called [GraphiQL](https://github.com/graphql/graphiql). That's
+an interactive in-browser GUI for communicating with the GraphQL instance.
+
+GraphiQL is available under `/graphiql` in your browser.
+
+## Secured connection (WebSocket)
+
+A WebSocket connection can be used for communicating with GraphQL.
+One example would be the `chatMessageAdded` event (subscriptions).
+
+By default, this WebSocket connection can be established in unsecured mode, only (`ws://`). If you want to use the 
+secured version (`wss://`), there's a slight modification to be made:
+
+Currently, there's no way of connecting **directly** to the secured WebSocket. So you'll need to set up a kind of 
+reverse proxy, that takes a standard HTTP connection and upgrades it to a WebSocket.
+
+For example, for the nginx webserver, it could look like this: 
+
+```
+server {
+    listen 443 ssl;
+    # That's the HTTPS config (...)
+    server_name my.example.com
+
+    location /websocket-example {
+        proxy_pass http://127.0.0.1:3100;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+}
+```
+
+In your application, you can use the following URI pattern:
+
+```
+wss://my.example.com/websocket-example/
+```


### PR DESCRIPTION
Recently, I tried out Rocket.Chat GraphQL for the very first time. The use case was to fetch `n` messages of a given room (initially via query, then live-updates via subscription).

When using the subscription part, I stumbled upon the lack of being able to use a secured connection (`wss://`). As described in https://github.com/RocketChat/Rocket.Chat/issues/13547, the only suitable way of using the secured mode is having a kind of reverse proxy.

**This PR tries to enhance the GraphQL documentation by adding information about the `setup` process.**

