### PR TITLE
[Improvement] Make APIs example code blocks editable

### DIFF
--- a/main.js
+++ b/main.js
@@ -284,6 +284,29 @@
     }
   }
 
+  // make code blocks editable
+  (function () {
+    var url = window.location.href;
+
+    makePreEditable();
+
+    window.addEventListener('click', function() {
+      if (url !== window.location.href) {
+        url = window.location.href;
+        setTimeout(function() {
+          makePreEditable();
+        }, 2000)
+      }
+    })
+
+    function makePreEditable() {
+      var pres = document.querySelectorAll('pre');
+      pres.forEach(function(pre) {
+        pre.setAttribute('contenteditable', 'true');
+      });
+    }
+  })();
+
   (function () {
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {


### PR DESCRIPTION
Hi, @MartinSchoeler ! I added a feature for the documentation. With this patch, users can replace the specific content before copying the example code as shown below.
![demo](https://user-images.githubusercontent.com/32427260/55290616-0ad95e80-5408-11e9-9222-1aa82b65d691.gif)
