### PR TITLE
Update Documentation: Add reference to standalone AlertManager WebHook Receiver

### DIFF
--- a/administrator-guides/integrations/prometheus/README.md
+++ b/administrator-guides/integrations/prometheus/README.md
@@ -1,6 +1,16 @@
 # Prometheus
 
 [Prometheus](https://prometheus.io/) is an open-source systems monitoring and alerting toolkit.
-To integrate alerts from Prometheus' Alertmanager follow the install instructions here:
+To integrate alerts from Prometheus' Alertmanager, you have two options, depending of your deployment strategy.
+
+## Incoming WebHook Script
+
+You can copy/paste a script, using the Rocket.Chat Incoming WebHook feature. Follow the install instructions here:
 
 <https://github.com/pavel-kazhavets/AlertmanagerRocketChat>
+
+## AlertManager WebHook Receiver
+
+You can configure a standalone AlertManager WebHook receiver that can be deployed and updated independently from Rocket.Chat. Follow the install instructions here:
+
+<https://github.com/FXinnovation/alertmanager-webhook-rocketchat>


### PR DESCRIPTION
Hi, 
This PR adds a standalone option to integrate Prometheus' Alertmanager to Rocket.Chat doc. As it uses the Rocket.Chat API, it provides a different (modular) deployment possibility; as such, I don't see it as a duplicate of the other alternative.
Thanks!
