### PR TITLE
Correct Rate Limit reset documentation

### DIFF
--- a/developer-guides/rest-api/rate-limiter/README.md
+++ b/developer-guides/rest-api/rate-limiter/README.md
@@ -10,9 +10,9 @@ or by providing a valid configuration object with the desired configuration, in 
 
 The rate limiter is set by default in the development environment and can be disabled in the admin panel in the `Administration Panel => Rate Limiter => API Rate Limiter`.
 
-For requests that are made and **exceed** the limit set by the rate limiter, three extra properties will be sent by the request headers.
+For requests that are made to an api endpoint with a rate limiter, three extra properties will be sent by the request headers.
 
 1. `x-ratelimit-limit`: The number of calls allowed for a certain amount of time.
 2. `x-ratelimit-remaining`: The number of requests remaining in the current rate limit window.
-3. `x-ratelimit-reset`: The time at which the current rate limit window resets in [UTC epoch seconds](https://en.wikipedia.org/wiki/Unix_time).
+3. `x-ratelimit-reset`: The time at which the current rate limit window resets in [UTC epoch milliseconds](https://en.wikipedia.org/wiki/Unix_time).
 


### PR DESCRIPTION
I've been working on a project using the Rocket Chat API and have noticed a couple of places where the documentation is incorrect or out of date. First, the three rate limit properties seem to be sent with _every_ API call (tested on `/api/v1/channels.history` at least) and second the rate limit reset header seems to be provided in _milli_seconds, not seconds. Example from a server I'm on: `1562287945706`.

Are these behaviors configurable by the server owner (in which case I assume additional doc changes are necessary)?