### PR TITLE
Rename Livechat routing methods

### DIFF
--- a/administrator-guides/livechat/livechat-queues/README.md
+++ b/administrator-guides/livechat/livechat-queues/README.md
@@ -2,11 +2,11 @@
 
 There are three types of queue types on Rocket.Chat:
 
-- [Round robin [default]](#round-robin)
-- [Guest Pool](#guest-pool)
+- [Auto Selection [default]](#auto-selection)
+- [Manual Selection](#manual-selection)
 - [External Service](#external-service)
 
-## Round robin
+## Auto Selection
 
 Each new chat will be routed to the agent that are accepting chats with the lower count.
 If there are more then one available agent with the same count the chat will get the first in order.
@@ -23,7 +23,7 @@ and the `agent-1`'s count will be increased to `1`:
 A new incoming chat will be routed to `agent-2` and so on until all agents have one chat each.
 So the next round comes, starting with `agent-1`.
 
-## Guest Pool
+## Manual Selection
 
 With this queue method active, agents will have a new `Incoming Livechats` section:
 
@@ -32,11 +32,8 @@ With this queue method active, agents will have a new `Incoming Livechats` secti
 Each new chat will be available on the `Incoming Livechats` section to **all** agents. So any agent can
 take a new incoming chat.
 
-When the agent clicks on the incoming Livechat, the system will show the first messages sent by the visitor, so the
-agent can decide if he will take the chat or not:
-
-![image](https://cloud.githubusercontent.com/assets/8620042/15939960/a31a5b64-2e3f-11e6-9a99-f375b66e6a9d.png)
-
+When the agent clicks on the incoming Livechat, the system will show the preview of the chat cotaining the messages sent by the visitor, so the
+agent can decide if he will take the chat or not.
 If the agent decides to take it, the incoming chat will be removed from the incoming chats list of the other agents.
 
 ## External Service


### PR DESCRIPTION
We renamed the Livechat routing methods on `2.0` release, as described below:

- From: **Round Robin** To: **Auto Selection**
- From: **Guest Pool** To: **Manual Selection**