### PR TITLE
DOCS: fix md link

### DIFF
--- a/installation/manual-installation/configuring-ssl-reverse-proxy/README.md
+++ b/installation/manual-installation/configuring-ssl-reverse-proxy/README.md
@@ -175,4 +175,4 @@ your_domain.com {
 
 ## Multi Instance Nginx reverse proxy
 
-Here is a link to a [Nginx multi instance reverse proxy example](../../installation/manual-installation/multiple-instances-to-improve-performance)
+Here is a link to a [Nginx multi instance reverse proxy example](../multiple-instances-to-improve-performance)

--- a/installation/manual-installation/configuring-ssl-reverse-proxy/README.md
+++ b/installation/manual-installation/configuring-ssl-reverse-proxy/README.md
@@ -175,4 +175,4 @@ your_domain.com {
 
 ## Multi Instance Nginx reverse proxy
 
-Here is a link to a [Nginx multi instance reverse proxy example] (../../installation/manual-installation/multiple-instances-to-improve-performance)
+Here is a link to a [Nginx multi instance reverse proxy example](../../installation/manual-installation/multiple-instances-to-improve-performance)


### PR DESCRIPTION
Remove space between ] and ( that broke the markdown link.
Also fix the relative path that was wrong.