### PR TITLE
Fix Documentation: Fix the protocol headers in the example server configs

### DIFF
--- a/installation/community-supported-installation/opensuse.md
+++ b/installation/community-supported-installation/opensuse.md
@@ -376,8 +376,8 @@ server {
     proxy_set_header Connection "upgrade";
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forward-Proto http;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Nginx-Proxy true;
     proxy_redirect off;
   }

--- a/installation/docker-containers/README.md
+++ b/installation/docker-containers/README.md
@@ -233,8 +233,8 @@ Delete the example in this file, and paste in the following:
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forward-Proto http;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Nginx-Proxy true;
             proxy_redirect off;
         }

--- a/installation/manual-installation/configuring-ssl-reverse-proxy.md
+++ b/installation/manual-installation/configuring-ssl-reverse-proxy.md
@@ -54,7 +54,7 @@ server {
 
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forward-Proto http;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Nginx-Proxy true;
 
         proxy_redirect off;
@@ -78,7 +78,7 @@ location ~ ^/.* {
 
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
-    proxy_set_header X-Forward-Proto http;
+    proxy_set_header X-Forwarded-Proto http;
     proxy_set_header X-Nginx-Proxy true;
     proxy_http_version 1.1;
 

--- a/installation/manual-installation/multiple-instances-to-improve-performance.md
+++ b/installation/manual-installation/multiple-instances-to-improve-performance.md
@@ -136,8 +136,8 @@ server {
         proxy_set_header Host $http_host;
 
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forward-Proto http;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Nginx-Proxy true;
 
         proxy_redirect off;

--- a/installation/paas-deployments/aws/README.md
+++ b/installation/paas-deployments/aws/README.md
@@ -117,8 +117,8 @@ We will use Let's Encrypt to get a free & open-source SSL certificate:
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forward-Proto http;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto http;
             proxy_set_header X-Nginx-Proxy true;
             proxy_redirect off;
         }


### PR DESCRIPTION
The headers should be X-Forwarded-For and X-Forwarded-Proto and the
X-Forwarded-Proto should be https in the example server configs that
are using SSL.