### PR TITLE
Update Documentation: Add link to another webhook integration

### DIFF
--- a/guides/administrator-guides/integrations/prometheus.md
+++ b/guides/administrator-guides/integrations/prometheus.md
@@ -4,3 +4,6 @@
 
 [https://github.com/pavel-kazhavets/AlertmanagerRocketChat](https://github.com/pavel-kazhavets/AlertmanagerRocketChat)
 
+Another integration that creates more concise messages:
+
+[https://github.com/puzzle/prometheus-rocket-chat](https://github.com/puzzle/prometheus-rocket-chat)


### PR DESCRIPTION
Add a link to another integration that creates more concise messages.