### PR TITLE
Update Readme.md - SRV Record

### DIFF
--- a/administrator-guides/federation/README.md
+++ b/administrator-guides/federation/README.md
@@ -84,7 +84,7 @@ You must add two DNS records:
 #### SRV Record
 
 - Service: `_rocketchat`
-- Protocol: `_tcp`
+- Protocol: `_http`
 - Name: `mydomain.com`
 - Weight: `1`
 - Priority: `1`


### PR DESCRIPTION
When testing the Federation-config, rocketchat-server (at least version 2.4.2) looksup _rocketchat._http.mydomain.com and _rocketchat._https.mydomain.com SRV records and not _rocketchat_tcp.mydomain.com