### PR TITLE
Exclude Markdown rule MD046 to allow a combination of fenced and indented codeblocks

### DIFF
--- a/markdown-style.rb
+++ b/markdown-style.rb
@@ -11,11 +11,10 @@ exclude_rule 'MD033'
 exclude_rule 'MD036'
 exclude_rule 'MD040'
 exclude_rule 'MD041'
+exclude_rule 'MD046'
 
 rule 'MD003', :style => :atx
 rule 'MD007', :indent => 4
 rule 'MD029', :style => :ordered
 rule 'MD035', :style => "- - -"
 rule 'MD004', :style => :fenced
-
-


### PR DESCRIPTION
Currently it is not possible to have a fenced codeblock within an indentation. This is necessary if you want codeblocks within an element of a ordered list, without breaking the order


## Example

```
1. First item

    ```shell
    ls -la
    ```

2. Second item
```

## Use-case

My secondary PR to update our AWS docs will fail the CI because of this: #1618 

https://travis-ci.org/RocketChat/docs/builds/653653903#L448-L469