### PR TITLE
New Documentation: for user.getstatus and user.setstatus API endpoints

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -488,6 +488,7 @@
         - getPersonalAccessTokens
         - getPresence
         - get-preferences
+        - getStatus
         - getUsernameSuggestion
         - info
         - list
@@ -499,6 +500,7 @@
         - setAvatar
         - set-preferences
         - setActiveStatus
+        - setStatus
         - update
         - updateOwnBasicInfo
       - Video Conference:

--- a/contributing/documentation/documentation-map/README.md
+++ b/contributing/documentation/documentation-map/README.md
@@ -472,6 +472,7 @@ Here you can also find what articles are incomplete and missing.
             - getPersonalAccessTokens
             - getPresence
             - get-preferences
+            - getStatus
             - getUsernameSuggestion
             - info
             - list
@@ -483,6 +484,7 @@ Here you can also find what articles are incomplete and missing.
             - setAvatar
             - set-preferences
             - setActiveStatus
+            - setStatus
             - update
             - updateOwnBasicInfo
         - Video Conference:

--- a/developer-guides/rest-api/README.md
+++ b/developer-guides/rest-api/README.md
@@ -68,6 +68,7 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | `/api/v1/users.getPersonalAccessTokens`       | Gets the user's personal access tokens.                         | [Link](users/getpersonalaccesstokens/)       |
 | `/api/v1/users.getPreferences`                | Gets all preferences of user.                                   | [Link](users/get-preferences/)               |
 | `/api/v1/users.getPresence`                   | Gets the online presence of a user.                             | [Link](users/getpresence/)                   |
+| `/api/v1/users.getStatus` | Gets the user's status. | [Link](users/getstatus/) |
 | `/api/v1/users.getUsernameSuggestion`         | Gets a suggestion a new username to user.                       | [Link](users/getusernamesuggestion/)         |
 | `/api/v1/users.info`                          | Gets a user's information, limited to the caller's permissions. | [Link](users/info/)                          |
 | `/api/v1/users.list`                          | All of the users and their information, limited to permissions. | [Link](users/list/)                          |
@@ -78,6 +79,7 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | `/api/v1/users.resetAvatar`                   | Reset a user's avatar                                           | [Link](users/resetavatar/)                   |
 | `/api/v1/users.setAvatar`                     | Set a user's avatar                                             | [Link](users/setavatar/)                     |
 | `/api/v1/users.setPreferences`                | Set user's preferences                                          | [Link](users/set-preferences/)               |
+| `/api/v1/users.setStatus` | Set the user's status | [Link](users/setstatus/) |
 | `/api/v1/users.setActiveStatus`               | Set a user's active status.                                     | [Link](users/setactivestatus/)               |
 | `/api/v1/users.update`                        | Update an existing user.                                        | [Link](users/update/)                        |
 | `/api/v1/users.updateOwnBasicInfo`            | Update basic information of own user.                           | [Link](users/updateownbasicinfo/)            |

--- a/developer-guides/rest-api/users/README.md
+++ b/developer-guides/rest-api/users/README.md
@@ -13,6 +13,7 @@
 | `/api/v1/users.getPersonalAccessTokens` | Gets the user's personal access tokens. | [Link](getpersonalaccesstokens/) |
 | `/api/v1/users.getPreferences` | Gets the user's preferences. | [Link](get-preferences/) |
 | `/api/v1/users.getPresence` | Gets the online presence of a user. | [Link](getpresence/) |
+| `/api/v1/users.getStatus` | Gets the user's status. | [Link](getstatus/) |
 | `/api/v1/users.getUsernameSuggestion` | Gets a suggestion a new username to user. | [Link](getusernamesuggestion/) |
 | `/api/v1/users.info` | Gets a user's information, limited to the caller's permissions. | [Link](info/) |
 | `/api/v1/users.list` | All of the users and their information, limited to permissions. | [Link](list/) |
@@ -23,6 +24,7 @@
 | `/api/v1/users.resetAvatar` | Reset a user's avatar | [Link](resetavatar/) |
 | `/api/v1/users.setAvatar` | Set a user's avatar | [Link](setavatar/) |
 | `/api/v1/users.setPreferences` | Set a user's preferences | [Link](set-preferences/) |
+| `/api/v1/users.setStatus` | Set the user's status | [Link](setstatus/) |
 | `/api/v1/users.setActiveStatus` | Set a user's active status. | [Link](setactivestatus/) |
 | `/api/v1/users.update` | Update an existing user. | [Link](update/) |
 | `/api/v1/users.updateOwnBasicInfo` | Update basic information of own user.| [Link](updateownbasicinfo/)               |

--- a/developer-guides/rest-api/users/getstatus/README.md
+++ b/developer-guides/rest-api/users/getstatus/README.md
@@ -1,0 +1,57 @@
+# Get Status
+
+Gets a user's Status if the query string `userId` or `username` is provided, otherwise it gets the callee's.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/users.getStatus` | `yes` | `GET` |
+
+## Query Parameters
+
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `userId` or `username` | `BsNr28znDkG8aeo7W` | Optional | The id or username of the user. If not provided, the auth user is used. |
+
+## Example Call
+
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/users.getStatus?userId=BsNr28znDkG8aeo7W
+```
+
+## Example Result
+
+```json
+{
+    "message": "My status update",
+    "connectionStatus": "online",
+    "status": "away",
+    "success": true
+}
+```
+
+## Self Example Call
+
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/users.getStatus
+```
+
+## Example Result
+
+```json
+{
+    "message": "Latest status",
+    "connectionStatus": "online",
+    "status": "online",
+    "success": true
+}
+```
+
+## Change Log
+
+| Version | Description |
+| :--- | :--- |
+| 1.2.0 | Added |

--- a/developer-guides/rest-api/users/setstatus/README.md
+++ b/developer-guides/rest-api/users/setstatus/README.md
@@ -6,7 +6,6 @@ Sets a user Status when the status message and state is given.
 | :--- | :--- | :--- |
 | `/api/v1/users.setStatus` | `yes` | `POST` |
 
-
 ## Arguments
 
 | Argument | Example | Required | Description |

--- a/developer-guides/rest-api/users/setstatus/README.md
+++ b/developer-guides/rest-api/users/setstatus/README.md
@@ -19,7 +19,7 @@ Sets a user Status when the status message and state is given.
 curl -H "X-Auth-Token: 40tB-Cn5YQJ74QMlQXi4Zf4E_-e0P5CrklU2pWOtV9M" \
      -H "X-User-Id: uunbZHiuEnib8Pawj" \
      -d '{"message":"My status update", "status": "online"}' \
-     https://graphql.rocket.chat/api/v1/users.setStatus
+     http://localhost:3000/api/v1/users.setStatus
 ```
 
 ## Example Result

--- a/developer-guides/rest-api/users/setstatus/README.md
+++ b/developer-guides/rest-api/users/setstatus/README.md
@@ -1,0 +1,38 @@
+# Set Status
+
+Sets a user Status when the status message and state is given.
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/users.setStatus` | `yes` | `POST` |
+
+
+## Arguments
+
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `message` | `My status update.` | Required | The user's status message. |
+| `status` | `online` | Optional | The user's status like `online`, `away`, `busy`, `invisible`. |
+
+## Example Call
+
+```bash
+curl -H "X-Auth-Token: 40tB-Cn5YQJ74QMlQXi4Zf4E_-e0P5CrklU2pWOtV9M" \
+     -H "X-User-Id: uunbZHiuEnib8Pawj" \
+     -d '{"message":"My status update", "status": "online"}' \
+     https://graphql.rocket.chat/api/v1/users.setStatus
+```
+
+## Example Result
+
+```json
+{
+    "success": true
+}
+```
+
+## Change Log
+
+| Version | Description |
+| :--- | :--- |
+| `1.2.0`| Added|


### PR DESCRIPTION
The /users.setStatus and /users.getStatus api endpoints now have a documentation.

Fixes #1543 

~initially was this #1598~