### PR TITLE
MMAPv1 deprecated

### DIFF
--- a/installation/manual-installation/debian.md
+++ b/installation/manual-installation/debian.md
@@ -104,7 +104,7 @@ PORT=3000
 Setup storage engine and replication for MongoDB \(mandatory for versions &gt; 1\), and enable and start MongoDB and Rocket.Chat:
 
 ```bash
-sudo sed -i "s/^#  engine:/  engine: mmapv1/"  /etc/mongod.conf
+sudo sed -i "s/^#  engine:/  engine: wiredTiger/"  /etc/mongod.conf
 ```
 
 ```bash


### PR DESCRIPTION
Starting in version 4.2, MongoDB removes the deprecated MMAPv1 storage engine

See also: https://docs.mongodb.com/manual/reference/configuration-options/#removed-mmapv1-options