### PR TITLE
Update README.md (rest-api/users/setstatus)

### DIFF
--- a/developer-guides/rest-api/users/setstatus/README.md
+++ b/developer-guides/rest-api/users/setstatus/README.md
@@ -11,7 +11,7 @@ Sets a user Status when the status message and state is given.
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `message` | `My status update.` | Required | The user's status message. |
-| `status` | `online` | Optional | The user's status like `online`, `away`, `busy`, `invisible`. |
+| `status` | `online` | Optional | The user's status like `online`, `away`, `busy`, `offline`. |
 
 ## Example Call
 


### PR DESCRIPTION
https://rocket.chat/docs/developer-guides/realtime-api/method-calls/user-presence/ list possible values as `online`, `away`, `busy`, `offline` -- **`offline`** , not `invisible`. 

POST with '{"message":"My status update", "status": "invisible"}' will cause 'BAD REQUEST', while POST with `offline` will succeed.