### PR TITLE
Fix Documentation: Rocket.Chat in Ubuntu

### DIFF
--- a/installation/manual-installation/ubuntu/README.md
+++ b/installation/manual-installation/ubuntu/README.md
@@ -72,7 +72,7 @@ tar -xzf /tmp/rocket.chat.tgz -C /tmp
 Install (this guide uses /opt but feel free to choose a different directory):
 
 ```bash
-cd /tmp/bundle/programs/server && npm install
+cd /tmp/bundle/programs/server && sudo npm install
 ```
 
 ```bash


### PR DESCRIPTION
There is a missing "sudo" in the command `cd /tmp/bundle/programs/server && npm install` . This creates a few errors in downloading dependencies that need sudo privileges. 