### PR TITLE
[NEW] Add the ability to share Account custom fields to external applications

### DIFF
--- a/administrator-guides/custom-fields/README.md
+++ b/administrator-guides/custom-fields/README.md
@@ -29,11 +29,17 @@ Make sure to use a valid `JSON`, where `keys` are the `field names` containing a
   "required": true,
   "minLength": 2,
   "maxLength": 10
+ },
+ "crmUserId": {
+  "type": "text",
+  "required": false,
+  "minLength": 12,
+  "sendToIntegrations": true,
  }
 }
 ```
 
-In the example above we set two new fields with the following properties:
+In the example above we set three new fields with the following properties:
 
 - **type**: defines the type of the field, currently there are 2 types: `select` and `text`, where `select` creates a dropdown list, and `text` creates a plain text form.
 
@@ -56,5 +62,7 @@ In the example above we set two new fields with the following properties:
 - **public**: defines the field as visible for other users when looking at this user's profile.
 
 - **private**: defines the field as private, so only users with `view-full-other-user-info` permission can see this field when viewing this user's profile.
+
+- **sendToIntegrations**: define the field as shareable with external applications, such as Omnichannel integrations.
 
 **Note**: Fields work with `tabs` for indentation, avoid using `spaces`.


### PR DESCRIPTION
We are now supporting a new custom field property for user accounts, called `sendToIntegrations`.
The new property will allow you to share the fields that have this property with external systems, such as CRM, external applications and so on.

The Omnichannel CRM integration will use this new feature, sharing all of the user custom fields that have the `sendToIntegrations` configured, like the example below:

```
{
...
    sendToIntegrations: true,
...
}
```

To get more details about this new feature, please take a look at [this PR](https://github.com/RocketChat/Rocket.Chat/pull/16286).