### PR TITLE
Supported OS : ubuntu 20.04 added

### DIFF
--- a/installation/rocketchatctl/README.md
+++ b/installation/rocketchatctl/README.md
@@ -15,7 +15,7 @@ Currently rocketchatctl is supported in these Linux distributions:
 
 - Supported OS:
 
-    Ubuntu 18.04 and 19.04\
+    Ubuntu 18.04, 19.04, 20.04\
     CentOS 7\
     Debian 9
 


### PR DESCRIPTION
Rocket.chat is running IN 20.04LTS as same as it was running in 18.04LTS.