### PR TITLE
Show actual backticks in help for inline code

### DIFF
--- a/guides/user-guides/messaging.md
+++ b/guides/user-guides/messaging.md
@@ -103,7 +103,7 @@ Use the following symbols to format text as desired:
 * Bold: `*Lorem ipsum dolor*`
 * Italic: `_Lorem ipsum dolor_`
 * Strike: `~Lorem ipsum dolor~`
-* Inline code: `Lorem ipsum dolor`
+* Inline code: `` `Lorem ipsum dolor` ``
 * Image: `![Alt text](https://rocket.chat/favicon.ico)`
 * Link: `[Lorem ipsum dolor](https://www.rocket.chat/)` or `<https://www.rocket.chat/ |Lorem ipsum dolor>`
 


### PR DESCRIPTION
Before this the help wouldn't explain how to achieve inline code:

![screenie](https://user-images.githubusercontent.com/227934/83248071-ca5ca880-a1a4-11ea-8145-9b16b39d44c4.png)

An alternative would be to actually use a `<code>`-block:

```
* Inline code: <code>`Lorem ipsum dolor`</code>
```

Please review.