### PR TITLE
Added 'ssl http2' to the nginx vHost

### DIFF
--- a/installation/manual-installation/configuring-ssl-reverse-proxy.md
+++ b/installation/manual-installation/configuring-ssl-reverse-proxy.md
@@ -32,7 +32,7 @@ upstream backend {
 
 # HTTPS Server
 server {
-    listen 443;
+    listen 443 ssl http2;
     server_name your_hostname.com;
 
     # You can increase the limit if your need to.


### PR DESCRIPTION
Without the `ssl`, no SSL connection can be established (e.g. Firefox says "SSL_ERROR_RX_RECORD_TOO_LONG"). So this one is mandatory.

`http2` is for HTTP/2 support which should be save to use.