### PR TITLE
Update README.md

### DIFF
--- a/guides/administrator-guides/white-labeling/README.md
+++ b/guides/administrator-guides/white-labeling/README.md
@@ -6,6 +6,6 @@ In these guides we will be talking about customizations without changing the sou
 
 We will be separating these guides into 2 categories: basic and advanced.
 
-* [Basic White-Labeling](./)
-* [Advanced White-Labeling](./)
+* [Basic White-Labeling](./advanced-white-labeling)
+* [Advanced White-Labeling](./basic-white-labeling)
 


### PR DESCRIPTION
The links to Basic and Advanced simply point to white labeling. Updated them to point to the right pages.