### PR TITLE
Add groups.online REST API documentation

### DIFF
--- a/api/rest-api/README.md
+++ b/api/rest-api/README.md
@@ -153,6 +153,7 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | `/api/v1/groups.members` | Gets the users of participants of a private group. | [Link](methods/groups/members.md) |
 | `/api/v1/groups.messages` | Retrieves all group messages. | [Link](methods/groups/messages.md) |
 | `/api/v1/groups.moderators` | List all moderators of a group. | [Link](methods/groups/moderators.md) |
+| `/api/v1/groups.online` | List all online users of a group. | [Link](methods/groups/online.md) |
 | `/api/v1/groups.open` | Adds the private group back to the list of groups. | [Link](methods/groups/open.md) |
 | `/api/v1/groups.removeLeader` | Removes the role of Leader for a user in the current group. | [Link](methods/groups/removeleader.md) |
 | `/api/v1/groups.rename` | Changes the name of the private group. | [Link](methods/groups/rename.md) |

--- a/api/rest-api/methods/groups/README.md
+++ b/api/rest-api/methods/groups/README.md
@@ -27,6 +27,7 @@ description: REST API Groups Methods
 | `/api/v1/groups.moderators` | List all moderators of a group. | [Link](moderators.md) |
 | `/api/v1/groups.members` | Gets the users of participants of a private group. | [Link](members.md) |
 | `/api/v1/groups.messages` | Retrieves all group messages. | [Link](messages.md) |
+| `/api/v1/groups.online` | List all online users of a group. | [Link](online.md) |
 | `/api/v1/groups.open` | Adds the private group back to the list of groups. | [Link](open.md) |
 | `/api/v1/groups.removeLeader` | Removes the role of Leader for a user in the current group. | [Link](removeleader.md) |
 | `/api/v1/groups.removeModerator` | Removes the role of moderator from a user in a group. | [Link](removemoderator.md) |

--- a/api/rest-api/methods/groups/online.md
+++ b/api/rest-api/methods/groups/online.md
@@ -1,0 +1,69 @@
+# Group Online
+
+Lists all online users of a group if the group's id is provided, otherwise it gets all online users of all groups. It supports the [Query Parameters only](../../query-and-fields-info.md#query-example).
+
+| URL | Requires Auth | HTTP Method |
+| :--- | :--- | :--- |
+| `/api/v1/groups.online` | `yes` | `GET` |
+
+## Query Parameters
+
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `query` | `{"_id":"5HmCfpoB7jp2uibTC"}` | Optional | See [Query Parameter](../../query-and-fields-info.md) |
+
+## Example Call
+
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+http://localhost:3000/api/v1/groups.online
+```
+
+## Example Result
+
+```javascript
+{
+  "online": [
+    {
+      "_id": "47cRd58HnWwpqxhaZ",
+      "username": "test"
+    },
+    {
+      "_id": "BsxzC22xQ43taWdff",
+      "username": "uniqueusername"
+    }
+  ],
+  "success": true
+}
+```
+
+## Query Example Call
+
+This example shows how to filter using group's id.
+
+```bash
+curl -H "X-Auth-Token: 9HqLlyZOugoStsXCUfD_0YdwnNnunAJF8V47U3QHXSq" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+http://localhost:3000/api/v1/groups.online?query={"_id": "5HmCfpoB7jp2uibTC"}
+```
+
+## Query Example Result
+
+```javascript
+{
+  "online": [
+    {
+      "_id": "47cRd58HnWwpqxhaZ",
+      "username": "test"
+    }
+  ],
+  "success": true
+}
+```
+
+## Change Log
+
+| Version | Description |
+| :--- | :--- |
+| 0.52.0 | Added |


### PR DESCRIPTION
The `groups.online` REST API was added in the same release as `channels.online` (v0.52.0) but for what ever reason the documentation was only added for `channels.online`. The methods themselves in the APIs are practically the same so I've just copy/pasted the existing documentation for `channels.online` and updated the references.

Commit adding the API: https://github.com/RocketChat/Rocket.Chat/commit/0810264bdbfa30c5993bba23bcd18b53cb74af29

