### PR TITLE
Update configuring-ssl-reverse-proxy.md

### DIFF
--- a/installation/manual-installation/configuring-ssl-reverse-proxy.md
+++ b/installation/manual-installation/configuring-ssl-reverse-proxy.md
@@ -46,7 +46,7 @@ server {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # don’t use SSLv3 ref: POODLE
 
     location / {
-        proxy_pass http://backend/;
+        proxy_pass http://backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Changed

proxy_pass http://backend/

to

proxy_pass http://backend

to allow Nginx to function properly.

Tested with Nginx 1.14.2 on Debian Buster.

See also here: https://forums.rocket.chat/t/problems-with-reverse-proxy/7506/3