### PR TITLE
Conform text to "correct" example

### DIFF
--- a/contributors/contributing/documentation/markdown-styleguide.md
+++ b/contributors/contributing/documentation/markdown-styleguide.md
@@ -86,7 +86,7 @@ Setext style H2
 
 ### MD004 - Unordered list style
 
-Lists should be created using dashes.
+Lists should be created using asterisks.
 
 **Wrong**:
 


### PR DESCRIPTION
MD004 Instruction suggested dashes, all examples on the page used asterisks.