### PR TITLE
Correcting the student name for sponsored projects

### DIFF
--- a/contributors/gsoc/google-summer-of-code-2020.md
+++ b/contributors/gsoc/google-summer-of-code-2020.md
@@ -71,7 +71,7 @@ Furthermore, Viasat, one of Rocket.Chat's long-time community supporters, has ag
 
 | Student | Sponsored Project | Mentors |
 | :--- | :--- | :--- |
-| Subham Sahoo | Live agent and chatbot handoff app | David Lassalle, Steve Stetak, Renato Becker, Marcos Defendi |
+| Prajval Raval | Live agent and chatbot handoff app | David Lassalle, Steve Stetak, Renato Becker, Marcos Defendi |
 | Kashish Jayasi | Rocket.Chat mobile site | Peter Lepeska, Eric Rosenthal, Karan Bedi |
 
 This, in combination, allowed us to accommodate a total of **TWELVE** enthusiastic students this summer season.


### PR DESCRIPTION
Subham Sahoo was removed from the GSoC'20 and I am the student who replaced him. I would like it if the doc showed my name instead. Thanks