### PR TITLE
Add password fallback instructions to docs

### DIFF
--- a/api/rest-api/2fa.md
+++ b/api/rest-api/2fa.md
@@ -77,6 +77,41 @@ If the user didn't receive the code it's possible to request the server to send 
 await APIClient.v1.post('users.2fa.sendEmailCode', undefined, {emailOrUsername: '{{emailOrUsername}}'});
 ```
 
+## Handling password fallback
+
+If an api request returns TOTP Required with a method *password*, then the API user's password is required to authenticate the request:
+
+```javascript
+// Error example
+{
+  "success":false,
+  "error":"TOTP Required [totp-required]",
+  "errorType":"totp-required",
+  "details":{
+    "method":"password",
+    "codeGenerated":false,
+    "availableMethods":[]
+  }
+}
+```
+
+### Request \(new headers\)
+
+The request must be resubmitted to the same end-point with the two additional headers
+
+* **X-2fa-code**: \(string\) The API user's password sha256 hashed;
+* **X-2fa-method**: 'password';
+
+```bash
+curl -H "X-Auth-Token: $YOUR_AUTH_TOEKN" \
+     -H "X-User-Id: $YOUR_USER_ID" \
+     -H "Content-type:application/json" \
+     -H "X-2fa-code:$SHA_256_HASH_OF_API_USER_PASSWORD" \
+     -H "X-2fa-method:password" \
+     http://localhost:3000/api/v1/users.update \
+     -d '{"userId": "SOME_USER_ID", "data": { "requirePasswordChange": false }}'   
+```
+
 ## Enabling the Two Factor via Email
 
 It's possible to enable the email check by calling the endpoint `users.2fa.enable-email` via POST. Note that the two factor via email will only work if the user has at least one verified email.

--- a/api/rest-api/2fa.md
+++ b/api/rest-api/2fa.md
@@ -103,7 +103,7 @@ The request must be resubmitted to the same end-point with the two additional he
 * **X-2fa-method**: 'password';
 
 ```bash
-curl -H "X-Auth-Token: $YOUR_AUTH_TOEKN" \
+curl -H "X-Auth-Token: $YOUR_AUTH_TOKEN" \
      -H "X-User-Id: $YOUR_USER_ID" \
      -H "Content-type:application/json" \
      -H "X-2fa-code:$SHA_256_HASH_OF_API_USER_PASSWORD" \

--- a/api/rest-api/2fa.md
+++ b/api/rest-api/2fa.md
@@ -105,9 +105,9 @@ The request must be resubmitted to the same end-point with the two additional he
 ```bash
 curl -H "X-Auth-Token: $YOUR_AUTH_TOKEN" \
      -H "X-User-Id: $YOUR_USER_ID" \
-     -H "Content-type:application/json" \
-     -H "X-2fa-code:$SHA_256_HASH_OF_API_USER_PASSWORD" \
-     -H "X-2fa-method:password" \
+     -H "Content-type: application/json" \
+     -H "X-2fa-code: $SHA_256_HASH_OF_API_USER_PASSWORD" \
+     -H "X-2fa-method: password" \
      http://localhost:3000/api/v1/users.update \
      -d '{"userId": "SOME_USER_ID", "data": { "requirePasswordChange": false }}'   
 ```
@@ -141,4 +141,3 @@ It's possible to disabled the email check by calling the endpoint `users.2fa.dis
 ```javascript
 await APIClient.v1.post('users.2fa.disable-email');
 ```
-


### PR DESCRIPTION
As proposed in https://github.com/RocketChat/Rocket.Chat/issues/18823

This just adds instructions on how to handle password fallback to the api docs