### PR TITLE
Correct the format on the payload table

### DIFF
--- a/api/rest-api/methods/rooms/creatediscussion.md
+++ b/api/rest-api/methods/rooms/creatediscussion.md
@@ -12,7 +12,13 @@ Creates a new discussion for room. It requires at least one of the following per
 
 ## Payload
 
-\| `prid` \| `GENERAL` \| Required \| Parent room id of the discussion. \| \| `t_name` \| `discussion name` \| Required \| Discussion name. \| \| `users` \| `['rocket.cat']` \| Optional\| Array of users to join in the discussion, if not provide will be an empry array\(Note: if provided, it must be an array\). \| \| `pmid` \| `aobEgbghXfe543keqG` \| Optional \| Parent message id\(if the discussion comes from a message\). \| \| `reply` \| `reply of this discussion` \| Optional \| The reply of the discussion. \|
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `prid` | `GENERAL` | Required | Parent room id of the discussion. |
+| `t_name` | `discussion name` | Required | Discussion name. |
+| `users` | `['rocket.cat']` | Optional | Array of users to join in the discussion, if not provide will be an empry array\(Note: if provided, it must be an array\). |
+| `pmid` | `aobEgbghXfe543keqG` | Optional | Parent message id\(if the discussion comes from a message\). |
+| `reply` | `reply of this discussion` | Optional | The reply of the discussion. |
 
 ## Example Call
 


### PR DESCRIPTION
The current visualization of the table in the **Payload** section is not correct.
![image](https://user-images.githubusercontent.com/5427672/96295344-06769580-0fee-11eb-818a-497de66d7c88.png)
This change will reformat it to look something like this:
![image](https://user-images.githubusercontent.com/5427672/96295444-260dbe00-0fee-11eb-98a7-70d8ce69382f.png)
