### PR TITLE
Fixed: MD046 - Code block style was incomplete / wrong

### DIFF
--- a/contributors/contributing/documentation/markdown-styleguide.md
+++ b/contributors/contributing/documentation/markdown-styleguide.md
@@ -597,13 +597,8 @@ Code blocks should be fenced.
 
 **Correct**:
 
+<pre>
 ```text
-
+    codeblock using indentation.
 ```
-
-codeblock using fences.
-
-```text
-
-```
-
+</pre>


### PR DESCRIPTION
documenting code fences with code fences was here not done correctly (chicken-egg problem)
Solved this using <pre> tags in github markdown to mask triple backticks