### PR TITLE
Fixes mistyping

### DIFF
--- a/api/rest-api/methods/rooms/creatediscussion.md
+++ b/api/rest-api/methods/rooms/creatediscussion.md
@@ -16,8 +16,8 @@ Creates a new discussion for room. It requires at least one of the following per
 | :--- | :--- | :--- | :--- |
 | `prid` | `GENERAL` | Required | Parent room id of the discussion. |
 | `t_name` | `discussion name` | Required | Discussion name. |
-| `users` | `['rocket.cat']` | Optional | Array of users to join in the discussion, if not provide will be an empry array\(Note: if provided, it must be an array\). |
-| `pmid` | `aobEgbghXfe543keqG` | Optional | Parent message id\(if the discussion comes from a message\). |
+| `users` | `['rocket.cat']` | Optional | Array of users to join in the discussion, if not provide will be an empty array \(Note: if provided, it must be an array\). |
+| `pmid` | `aobEgbghXfe543keqG` | Optional | Parent message id \(if the discussion comes from a message\). |
 | `reply` | `reply of this discussion` | Optional | The reply of the discussion. |
 
 ## Example Call


### PR DESCRIPTION
Fixes mistyping on the [Create Discussion](https://docs.rocket.chat/api/rest-api/methods/rooms/creatediscussion) page.

| Before | After |
| :- | :- |
| "... if not provide will be an **empry** array\(Note:..." | "... if not provide will be an **empty** array \(Note:..."|
| "...Parent message id\(if the..." | "... Parent message id \(if the..."|