### PR TITLE
Add documentation for instances.get and licenses.* rest-api endpoints

### DIFF
--- a/api/rest-api/README.md
+++ b/api/rest-api/README.md
@@ -26,6 +26,7 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | `/api/v1/spotlight` | Searches for users or rooms that are visible to the user. | [Link](methods/miscellaneous/spotlight.md) |
 | `/api/v1/statistics` | Statistics about the Rocket.Chat server. | [Link](methods/miscellaneous/statistics.md) |
 | `/api/v1/statistics.list` | Selectable statistics about the Rocket.Chat server. | [Link](methods/miscellaneous/statistics-list.md) |
+| `/api/v1/instances.get` | Gets all running instances. | [Link](methods/miscellaneous/instances-get.md) |
 
 ### Assets
 
@@ -351,6 +352,12 @@ When calling a production Rocket.Chat server, ensure it is running via HTTPS and
 | Url | Short Description | Details Page |
 | :--- | :--- | :--- |
 | `/api/v1/webdav.getMyAccounts` | Retrieves the user's webdav accounts. | [Link](methods/webdav/getmyaccounts.md) |
+
+### Licenses
+| Url | Method | Short Description | Details Page |
+| :--- | :--- | :--- | :--- |
+| `/api/v1/licenses.get` | `GET` | Gets all active licenses. | [Link](methods/licenses/get.md) |
+| `/api/v1/licenses.add` | `POST` | Adds a new license. | [Link](methods/licenses/add.md) |
 
 ## Language specific wrappers
 

--- a/api/rest-api/methods/licenses/README.md
+++ b/api/rest-api/methods/licenses/README.md
@@ -1,0 +1,10 @@
+---
+description: REST API Licenses Methods
+---
+
+# Licenses
+| Url | Method | Short Description | Details Page |
+| :--- | :--- | :--- | :--- |
+| `/api/v1/licenses.get` | `GET` | Gets all active licenses. | [Link](methods/licenses/get.md) |
+| `/api/v1/licenses.add` | `POST` | Adds a new license. | [Link](methods/licenses/add.md) |
+

--- a/api/rest-api/methods/licenses/README.md
+++ b/api/rest-api/methods/licenses/README.md
@@ -5,6 +5,6 @@ description: REST API Licenses Methods
 # Licenses
 | Url | Method | Short Description | Details Page |
 | :--- | :--- | :--- | :--- |
-| `/api/v1/licenses.get` | `GET` | Gets all active licenses. | [Link](methods/licenses/get.md) |
-| `/api/v1/licenses.add` | `POST` | Adds a new license. | [Link](methods/licenses/add.md) |
+| `/api/v1/licenses.get` | `GET` | Gets all active licenses. | [Link](get.md) |
+| `/api/v1/licenses.add` | `POST` | Adds a new license. | [Link](add.md) |
 

--- a/api/rest-api/methods/licenses/add.md
+++ b/api/rest-api/methods/licenses/add.md
@@ -1,0 +1,38 @@
+# Add
+
+Adds a new license.
+
+| URL | Requires Auth | Required Permission | HTTP Method |
+| :--- | :--- |:--- | :--- |
+| `/api/v1/licenses.add` | `yes` | `edit-privileged-setting` | `POST` |
+
+## Payload
+
+| Argument | Example | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `license` | `k0HVkh8Fs...` | Required | The value of a valid license. |
+
+## Example Call
+
+```bash
+curl -H "Content-type:application/json" \
+     -H "X-Auth-Token: xytlUWJtCuxuDiwBfnoJpPR3qI7FWIB6LZbOKFeiIEu" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/licenses.get
+     -d '{"license": "k0HVkh8Fs..."}'
+```
+
+## Example Result
+
+```javascript
+{
+    "success": true
+}
+```
+
+## Change Log
+
+| Version | Description |
+| :--- | :--- |
+| 3.10 | Added |
+

--- a/api/rest-api/methods/licenses/get.md
+++ b/api/rest-api/methods/licenses/get.md
@@ -1,0 +1,41 @@
+# Get
+
+Gets all active licenses.
+
+| URL | Requires Auth | Required Permission | HTTP Method |
+| :--- | :--- |:--- | :--- |
+| `/api/v1/licenses.get` | `yes` | `view-privileged-setting` | `GET` |
+
+## Example Call
+
+```bash
+curl -H "X-Auth-Token: xytlUWJtCuxuDiwBfnoJpPR3qI7FWIB6LZbOKFeiIEu" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:3000/api/v1/licenses.get
+```
+
+## Example Result
+
+```javascript
+{
+    "licenses": [
+        {
+            "url": "localhost:3000",
+            "expiry": "2021-01-01",
+            "modules": [
+                "enterprise:*"
+            ],
+            "maxActiveUsers": 200,
+            "maxGuestUsers": 3,
+            "maxRoomsPerGuest": 10
+        }
+    ],
+        "success": true
+}
+```
+
+## Change Log
+
+| Version | Description |
+| :--- | :--- |
+| 3.10 | Added |

--- a/api/rest-api/methods/miscellaneous/README.md
+++ b/api/rest-api/methods/miscellaneous/README.md
@@ -14,4 +14,5 @@ Just some generic information, such as information about the server and authenti
 | `/api/v1/spotlight` | Searches for users or rooms that are visible to the user. | [Link](spotlight.md) |
 | `/api/v1/statistics` | Statistics about the Rocket.Chat server. | [Link](statistics.md) |
 | `/api/v1/statistics.list` | Selectable statistics about the Rocket.Chat server. | [Link](statistics-list.md) |
+| `/api/v1/instances.get` | Gets all running instances. | [Link](methods/miscellaneous/instances-get.md) |
 

--- a/api/rest-api/methods/miscellaneous/instances-get.md
+++ b/api/rest-api/methods/miscellaneous/instances-get.md
@@ -11,107 +11,43 @@ Gets all running instances.
 ```bash
 curl -H "X-Auth-Token: xytlUWJtCuxuDiwBfnoJpPR3qI7FWIB6LZbOKFeiIEu" \
      -H "X-User-Id: aobEdbYhXfu5hkeqG" \
-     http://localhost:24707/api/v1/instances.get
+     http://localhost:3000/api/v1/instances.get
 ```
 
 ## Example Result
 Result while running only **one** instance. 
 ```javascript
 {
-    "instances": {
-        "current": {
-            "instanceRecord": [
-                {
-                    "_id": "RbiRuWXpph2DGWNR9",
-                    "_createdAt": "2020-12-28T18:11:42.095Z",
-                    "_updatedAt": "2020-12-28T18:13:32.101Z",
-                    "extraInformation": {
-                        "host": "undefined",
-                        "port": "24707"
-                    },
-                    "name": "rocket.chat",
-                    "pid": 67202
-                }
-            ]
-        },
-        "connections": []
-    },
-    "success": true
-}
-```
-
-## Example Call
-
-```bash
-curl -H "X-Auth-Token: m_kJc3Y8yFlN8STWpHzWfbVYXl7lkJIlM9lMu1XfPV-" \
-     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
-     http://localhost:29227/api/v1/instances.get
-```
-
-## Example Result
-Result while running **two** instances.
-```javascript
-{
-    "instances": {
-        "current": {
-            "instanceRecord": [
-                {
-                    "_id": "HoRxanW9dpe5cJgEX",
-                    "_createdAt": "2020-12-28T18:17:09.907Z",
-                    "_updatedAt": "2020-12-28T18:22:49.922Z",
-                    "extraInformation": {
-                        "host": "localhost",
-                        "port": "29227"
-                    },
-                    "name": "rocket.chat",
-                    "pid": 68447
-                }
-            ]
-        },
-        "connections": [
-            {
-                "address": "localhost:27687",
-                "currentStatus": {
-                    "status": "connected",
-                    "connected": true,
-                    "retryCount": 0
+    "instances": [
+        {
+            "_id": "nujL3Zb6wxYfKcRq9",
+            "_createdAt": "2020-12-29T17:03:19.425Z",
+            "_updatedAt": "2020-12-29T17:04:59.434Z",
+            "extraInformation": {
+                "host": "undefined",
+                "port": "29703",
+                "os": {
+                    "type": "Linux",
+                    "platform": "linux",
+                    "arch": "x64",
+                    "release": "4.19.128-microsoft-standard",
+                    "uptime": 11250,
+                    "loadavg": [
+                        1.4970703125,
+                        1.5146484375,
+                        1.48486328125
+                    ],
+                    "totalmem": 6594183168,
+                    "freemem": 263098368,
+                    "cpus": 12
                 },
-                "instanceRecord": {
-                    "_id": "bftXy4ACdss6B3djL",
-                    "_createdAt": "2020-12-28T18:16:58.835Z",
-                    "_updatedAt": "2020-12-28T18:17:08.840Z",
-                    "extraInformation": {
-                        "host": "localhost",
-                        "port": "27687"
-                    },
-                    "name": "rocket.chat",
-                    "pid": 68366
-                },
-                "broadcastAuth": true
+                "nodeVersion": "v12.18.4"
             },
-            {
-                "address": "localhost:23091",
-                "currentStatus": {
-                    "status": "connected",
-                    "connected": true,
-                    "retryCount": 0
-                },
-                "instanceRecord": {
-                    "_id": "Appx6LFgcn6XtWNrv",
-                    "_createdAt": "2020-12-28T18:19:08.762Z",
-                    "_updatedAt": "2020-12-28T18:19:08.762Z",
-                    "extraInformation": {
-                        "host": "localhost",
-                        "port": "23091"
-                    },
-                    "name": "rocket.chat",
-                    "pid": 68866
-                },
-                "broadcastAuth": true
-            }
-        ]
-    },
-    "success": true
+            "name": "rocket.chat",
+            "pid": 25877
+        }
+    ],
+        "success": true
 }
 ```
 

--- a/api/rest-api/methods/miscellaneous/instances-get.md
+++ b/api/rest-api/methods/miscellaneous/instances-get.md
@@ -1,0 +1,123 @@
+# Instances - Get
+
+Gets all running instances.
+
+| URL | Requires Auth | Required Permission | HTTP Method |
+| :--- | :--- |:--- | :--- |
+| `/api/v1/instances.get` | `yes` | `view-statistics` | `GET` |
+
+## Example Call
+
+```bash
+curl -H "X-Auth-Token: xytlUWJtCuxuDiwBfnoJpPR3qI7FWIB6LZbOKFeiIEu" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:24707/api/v1/instances.get
+```
+
+## Example Result
+Result while running only **one** instance. 
+```javascript
+{
+    "instances": {
+        "current": {
+            "instanceRecord": [
+                {
+                    "_id": "RbiRuWXpph2DGWNR9",
+                    "_createdAt": "2020-12-28T18:11:42.095Z",
+                    "_updatedAt": "2020-12-28T18:13:32.101Z",
+                    "extraInformation": {
+                        "host": "undefined",
+                        "port": "24707"
+                    },
+                    "name": "rocket.chat",
+                    "pid": 67202
+                }
+            ]
+        },
+        "connections": []
+    },
+    "success": true
+}
+```
+
+## Example Call
+
+```bash
+curl -H "X-Auth-Token: m_kJc3Y8yFlN8STWpHzWfbVYXl7lkJIlM9lMu1XfPV-" \
+     -H "X-User-Id: aobEdbYhXfu5hkeqG" \
+     http://localhost:29227/api/v1/instances.get
+```
+
+## Example Result
+Result while running **two** instances.
+```javascript
+{
+    "instances": {
+        "current": {
+            "instanceRecord": [
+                {
+                    "_id": "HoRxanW9dpe5cJgEX",
+                    "_createdAt": "2020-12-28T18:17:09.907Z",
+                    "_updatedAt": "2020-12-28T18:22:49.922Z",
+                    "extraInformation": {
+                        "host": "localhost",
+                        "port": "29227"
+                    },
+                    "name": "rocket.chat",
+                    "pid": 68447
+                }
+            ]
+        },
+        "connections": [
+            {
+                "address": "localhost:27687",
+                "currentStatus": {
+                    "status": "connected",
+                    "connected": true,
+                    "retryCount": 0
+                },
+                "instanceRecord": {
+                    "_id": "bftXy4ACdss6B3djL",
+                    "_createdAt": "2020-12-28T18:16:58.835Z",
+                    "_updatedAt": "2020-12-28T18:17:08.840Z",
+                    "extraInformation": {
+                        "host": "localhost",
+                        "port": "27687"
+                    },
+                    "name": "rocket.chat",
+                    "pid": 68366
+                },
+                "broadcastAuth": true
+            },
+            {
+                "address": "localhost:23091",
+                "currentStatus": {
+                    "status": "connected",
+                    "connected": true,
+                    "retryCount": 0
+                },
+                "instanceRecord": {
+                    "_id": "Appx6LFgcn6XtWNrv",
+                    "_createdAt": "2020-12-28T18:19:08.762Z",
+                    "_updatedAt": "2020-12-28T18:19:08.762Z",
+                    "extraInformation": {
+                        "host": "localhost",
+                        "port": "23091"
+                    },
+                    "name": "rocket.chat",
+                    "pid": 68866
+                },
+                "broadcastAuth": true
+            }
+        ]
+    },
+    "success": true
+}
+```
+
+## Change Log
+
+| Version | Description |
+| :--- | :--- |
+| 3.10 | Added |
+


### PR DESCRIPTION
Documentation for the new rest-api endpoints: `intances.get` and `licenses.*` (`licenses.get` and `licenses.add`).