### PR TITLE
Add a note on Rate limiter not always tweakable

### DIFF
--- a/api/rest-api/rate-limiter.md
+++ b/api/rest-api/rate-limiter.md
@@ -1,5 +1,7 @@
 # Rate Limiter
 
+> Note: Some endpoints (like `/api/v1/users.updateOwnBasicInfo`) might trigger the rate limiter and cannot currently be customized/disabled in `Administration Panel`
+
 The rate limiter is set by default on all api endpoints, with an amount set in the `Administration Panel => Rate Limiter => API Rate Limiter` for time interval \(in milliseconds\). To disable the rate limiter you can add the `api-bypass-rate-limit` permission for your user group role in the `Administration -> Permission`.
 
 To disable programmatically or change the rate limiter, such as the number of calls and the time interval, simply provide for the API function `.addRoute`, within the existing options object that already defines `authRequired: true/false`, a property `rateLimiterOptions`, providing `false` if you want disable the RateLimiter for this endpoint, or by providing a valid configuration object with the desired configuration, in the following format `{numRequestsAllowed: 10, intervalTimeInMS: 60000}`.


### PR DESCRIPTION
Some endpoints (like `/api/v1/users.updateOwnBasicInfo`) might trigger the rate limiter and cannot currently be customized/disabled in `Administration Panel` so I added a note about it.