### PR TITLE
It is not necessary to provide _id when posting to this endpoint.

### DIFF
--- a/api/rest-api/methods/chat/sendmessage.md
+++ b/api/rest-api/methods/chat/sendmessage.md
@@ -14,7 +14,7 @@ You only can send `alias` and `avatar` properties if your user has the `bot` rol
 
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
-| `message._id` | `ByehQjC44FwMeiLbX` | Required | The \_id of message. |
+| `message._id` | `ByehQjC44FwMeiLbX` | Optional | The \_id of message. |
 | `message.rid` | `ByehQjC44FwMeiLbX` | Required | The room id of where the message is to be sent. |
 | `message.tmid` | `ByehQCh2435MeiLbX` | Optional | The message's id to create a thread. |
 | `message.msg` | `Sample message` | Optional | The text of the message to send, is optional because of attachments. |


### PR DESCRIPTION
Maybe I got the desciption of how _id s of messages are derived wrong  but at least it is not required to provide an _id when posting to the endpoint.
Does the magic happen in the background?