### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/getting-support.md
+++ b/getting-support.md
@@ -67,7 +67,7 @@ Always update to the latest stable version before reporting any bugs or before a
 {% endhint %}
 
 {% hint style="info" %}
-**LTS** means "Long Time Support" and it's used to identify the last **minor** version before a **major** version, e.g. 2.4 is the last minor before 3.x. A new major version means that the version introduced a braking change and requires attention on the upgrade, so we maintain the support of the previous version for a longer time in order to give you more time to plan and test the upgrade.
+**LTS** means "Long Time Support" and it's used to identify the last **minor** version before a **major** version, e.g. 2.4 is the last minor before 3.x. A new major version means that the version introduced a breaking change and requires attention on the upgrade, so we maintain the support of the previous version for a longer time in order to give you more time to plan and test the upgrade.
 {% endhint %}
 
 ### Rocket.Chat Cloud

--- a/guides/administrator-guides/white-labeling/advanced-white-labeling.md
+++ b/guides/administrator-guides/white-labeling/advanced-white-labeling.md
@@ -24,11 +24,11 @@ This script runs after the user has logged out.
 
 ### Custom Script for Logged Out Users
 
-Custom Script that will run whenever a user that is not logged in access your server url. e.g. \(whenever you enter the login page\)
+Custom Script that will run whenever a user that is not logged in accesses your server url. e.g. \(whenever you enter the login page\)
 
 ### Custom Script for Logged In Users
 
-Custom Script that will run whenever a user that is logged in access your server url \(eg. opens a browser page or the desktop app\)
+Custom Script that will run whenever a user that is logged in accesses your server url \(eg. opens a browser page or the desktop app\)
 
 ## Email Templates
 

--- a/guides/user-guides/messaging.md
+++ b/guides/user-guides/messaging.md
@@ -4,7 +4,7 @@ This page explains the ins and outs of messaging in Rocket.Chat.
 
 ## Compose messages
 
-To compose a message in Rocket.Chat, go the channel or user you want to send a message. Type the message box and press Enter or the **Send** Button.
+To compose a message in Rocket.Chat, go to the channel or user you want to send a message. Type the message box and press Enter or the **Send** Button.
 
 If you want to add new lines of text, press Shift + Enter to add a new line.
 

--- a/guides/user-guides/messaging/README.md
+++ b/guides/user-guides/messaging/README.md
@@ -4,7 +4,7 @@ This page explains the ins and outs of messaging in Rocket.Chat.
 
 ## Compose messages
 
-To compose a message in Rocket.Chat, go the channel or user you want to send a message. Type the message box and press Enter or the **Send** Button.
+To compose a message in Rocket.Chat, go to the channel or user you want to send a message. Type the message box and press Enter or the **Send** Button.
 
 If you want to add new lines of text, press Shift + Enter to add a new line.
 


### PR DESCRIPTION
fix: correct breaking spelling in getting-support.md

fix: grammatical error 'go to the channel' in README.md

fix: grammatical error 'go to the channel' in messaging.md

fix: grammatical error 'accesses' in advanced-white-labeling.md