### PR TITLE
[TYPO] Change "ts" param of livechat/message to "ls"

### DIFF
--- a/api/rest-api/methods/livechat/message.md
+++ b/api/rest-api/methods/livechat/message.md
@@ -47,7 +47,7 @@ curl -X POST \
       "username": "guest-4",
       "name": "Livechat Visitor"
     },
-    "ts": "2018-09-14T13:31:33.201Z"
+    "ls": "2018-09-14T13:31:33.201Z"
   },
   "success": true
 }
@@ -105,7 +105,7 @@ curl -X PUT \
       "username": "guest-4",
       "name": "Livechat Visitor"
     },
-    "ts": "2018-09-14T13:31:33.201Z"
+    "ls": "2018-09-14T13:31:33.201Z"
   },
   "success": true
 }
@@ -142,7 +142,7 @@ curl -X DELETE \
 {
   "message": {
     "_id": "ZKWP8LfGnRHQ3ozWa",
-    "ts": "2018-09-14T13:31:33.279Z"
+    "ls": "2018-09-14T13:31:33.279Z"
   },
   "success": true
 }
@@ -171,7 +171,7 @@ curl -X DELETE \
 | Argument | Example | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `token` | `iNKE8a6k6cjbqWhWd` | Required | The visitor `token`. |
-| `ts` |  | Optional | The timestamp to start loading. |
+| `ls` |  | Optional | The timestamp to start loading. |
 | `end` |  | Optional | The timestamp limit to load. |
 | `limit` |  | Optional | The number of messages to load. |
 
@@ -191,7 +191,7 @@ curl http://localhost:3000/api/v1/livechat/messages.history/KuACMJ5MpN6SfAFWg?to
     "msg": "editing livechat message..",
     "token": "iNKE8a6k6cjbqWhWd",
     "alias": "Livechat Visitor",
-    "ts": "2018-09-14T13:31:33.201Z",
+    "ls": "2018-09-14T13:31:33.201Z",
     "u": {
       "_id": "YgEoq2djbGdjjZnsL",
       "username": "guest-4",


### PR DESCRIPTION
The livechat/message api expects the param `ls` for date as loading start but in docs its mentioned that it expects `ts` which creates confusion. 

Check the param requirement [here](https://github.com/RocketChat/Rocket.Chat/blob/eabb30472bd16a4000465ef1f06e5404dc4c1e2e/app/livechat/server/api/v1/message.js#L232)

This PR corrects this typo.