### PR TITLE
Fixing Wrong command in WSL2 guide

### DIFF
--- a/guides/developer/developing-on-windows-10.md
+++ b/guides/developer/developing-on-windows-10.md
@@ -35,7 +35,7 @@ Building Rocket.Chat code requires a minimum of 8 GB of RAM memory on the Linux 
 1. Open a **WSL 2 shell** \(not Powershell\). Update Linux `sudo apt-get update sudo apt-get dist-upgrade`
 2. Install tools required
 
-   `sudo apt-get build-essential git curl python-minimal`
+   `sudo apt-get install build-essential git curl python-minimal`
 
 3. Install meteor
 


### PR DESCRIPTION
### Earlier
The command given to install packages on WSL2 is - `sudo apt-get build-essential git curl python-minimal` which is not a valid command and produces the error below:- 
![image](https://user-images.githubusercontent.com/58601732/109209447-8f3de300-77d1-11eb-85f0-1fc2e3423d94.png)

### Now
We are missing `install` argument here, command should be -
`sudo apt-get install build-essential git curl python-minimal` which installs the mentioned packages.
![image](https://user-images.githubusercontent.com/58601732/109209711-e04dd700-77d1-11eb-9dc4-f48afc4ed361.png)

Here we can see packages being installed.