### PR TITLE
Added a new RewriteCond to the Apache SSL reverse proxy documentation

### DIFF
--- a/installation/manual-installation/configuring-ssl-reverse-proxy.md
+++ b/installation/manual-installation/configuring-ssl-reverse-proxy.md
@@ -133,6 +133,7 @@ Edit `/etc/apache2/sites-enabled/rocketchat.conf` and be sure to use your actual
     </Location>
 
     RewriteEngine On
+    RewriteCond %{HTTP:CONNECTION} Upgrade [NC]
     RewriteCond %{HTTP:Upgrade} =websocket [NC]
     RewriteRule /(.*)           ws://localhost:3000/$1 [P,L]
     RewriteCond %{HTTP:Upgrade} !=websocket [NC]


### PR DESCRIPTION
Added a new RewriteCond to the Apache SSL reverse proxy documentation to resolve an issue with `wss` on Rocket.Chat's mobile apps (official and white-label).