### PR TITLE
Fix Documentation: Fixed broken url for contacting mentor

### DIFF
--- a/contributors/gsoc/google-summer-of-code-2021.md
+++ b/contributors/gsoc/google-summer-of-code-2021.md
@@ -136,7 +136,7 @@ Interested students are also encouraged to interact with our core team and contr
 
 ### **App: Speech-to-Text**
 
-* **Mentors:** [@marcelo.schmidt](https://open.rocket.chat/marcelo.schmidt)
+* **Mentors:** [@marcelo.schmidt](https://open.rocket.chat/direct/marcelo.schmidt)
 * **Description:** This project aims to save a text version of an audio in the file metadata. This should be done server-side upon receiving the audio.
 * **Desirable Skills**: Familiarity with JavaScript and TypeScript. Knowledge in how to build Rocket.Chat Apps is a plus.
 
@@ -160,7 +160,7 @@ Interested students are also encouraged to interact with our core team and contr
 
 ### App: Bad-Words Filter
 
-* **Mentors:** [@marcelo.schmidt](https://open.rocket.chat/marcelo.schmidt) and [@douglas.gubert](https://open.rocket.chat/direct/douglas.gubert)
+* **Mentors:** [@marcelo.schmidt](https://open.rocket.chat/direct/marcelo.schmidt) and [@douglas.gubert](https://open.rocket.chat/direct/douglas.gubert)
 * **Description:** Rocket.Chat currently uses a third-party package to filter bad words. This poses a few problems, such as having to update the package every so often, having to check which words have been added or excluded in newer versions and deciding if we would like to keep blocking or allowing words. This project is for building an App that can be enabled in our Marketplace that will filter out a list of default bad words but will allow admins to add or delete words from that list. The app will need to cover the following requirements:
   * Create a UI for managing the App settings
   * Load a list of words from a URL
@@ -220,7 +220,7 @@ Interested students are also encouraged to interact with our core team and contr
 
 ### App: Global Translation
 
-* **Mentors:** [@marcelo.schmidt](https://open.rocket.chat/marcelo.schmidt)
+* **Mentors:** [@marcelo.schmidt](https://open.rocket.chat/direct/marcelo.schmidt)
 * **Description:** Rocket.Chat currently uses a package to provide message translations. This project aims to build that funcionality on an app, thus reducing the codebase of Rocket.Chat and allowing for easier configuration.
 * **Desirable Skills**: Familiarity with JavaScript and TypeScript. Knowledge in how to build Rocket.Chat Apps is a plus.
 


### PR DESCRIPTION
The initial url for contacting the mentor was missing the word "direct" and hence, directing towards a broken [page](https://open.rocket.chat/marcelo.schmidt).

![image](https://user-images.githubusercontent.com/46912583/111860307-b7ea7000-896c-11eb-8a4e-84877a2219c4.png)
