### PR TITLE
Fix typos in Create New team page

### DIFF
--- a/guides/user-guides/teams/create-a-new-team.md
+++ b/guides/user-guides/teams/create-a-new-team.md
@@ -4,11 +4,11 @@
 
 Setting up your first team is easy and both community and enterprise clients can access the feature. Follow the steps below to create your very first team:
 
-* Click in Create New - Team
+* Click on Create New - Team
 
 ![](../../../.gitbook/assets/image%20%28337%29.png)
 
-* Define privacy and encryption options for your team. Include all members who should join the team. Click in **Create**
+* Define privacy and encryption options for your team. Include all members who should join the team. Click on **Create**
 
 ![](../../../.gitbook/assets/image%20%28338%29.png)
 


### PR DESCRIPTION
There were some typos in the create new Team page. It should be 'click on' instead of 'click in'
