### PR TITLE
Adding Link on Schema Definition Page

### DIFF
--- a/api/schema-definition/README.md
+++ b/api/schema-definition/README.md
@@ -2,5 +2,5 @@
 
 Please find the document here: 
 
-
+[https://developer.rocket.chat/api/schema-definition/](https://developer.rocket.chat/api/schema-definition)
 


### PR DESCRIPTION
There was no link present on  schema Definition Page to redirect it to the Schema Definition Page