### PR TITLE
Update image references to use registry.rocket.chat endpoint

### DIFF
--- a/installation/automation-tools/openshift.md
+++ b/installation/automation-tools/openshift.md
@@ -12,7 +12,7 @@ This repository hosts some templates for provision Rocket.Chat in OpenShift.
 * Pull the Rocket.Chat Docker image from Docker Hub and tag/push to the internal OpenShift registry:
 
 ```bash
-docker pull rocketchat/rocket.chat
+docker pull registry.rocket.chat/rocketchat/rocket.chat
 docker tag rocketchat/rocket.chat hub.openshift.rhel-cdk.10.1.2.2.xip.io/openshift/rocket-chat
 docker push hub.openshift.rhel-cdk.10.1.2.2.xip.io/openshift/rocket-chat
 ```

--- a/installation/community-supported-installation/windows-10-pro.md
+++ b/installation/community-supported-installation/windows-10-pro.md
@@ -25,7 +25,7 @@ db:
   command: mongod --smallfiles --oplogSize 128
 
 rocketchat:
-  image: rocketchat/rocket.chat:latest
+  image: registry.rocket.chat/rocketchat/rocket.chat:latest
   environment:
     - PORT=3000
     - ROOT_URL=http://docker:3000

--- a/installation/docker-containers/available-images.md
+++ b/installation/docker-containers/available-images.md
@@ -17,7 +17,7 @@ docker pull rocket.chat
 This is an image that is maintained at Rocket.Chat's own docker repository. The release may be from the develop or master branch.
 
 ```bash
-docker pull rocketchat/rocket.chat:latest
+docker pull registry.rocket.chat/rocketchat/rocket.chat:latest
 ```
 
 ## Specific Release Image
@@ -25,7 +25,7 @@ docker pull rocketchat/rocket.chat:latest
 This is an image that is maintained at Rocket.Chat's own docker repository. It is associated with a release build.
 
 ```bash
-docker pull rocketchat/rocket.chat:X.X.X
+docker pull registry.rocket.chat/rocketchat/rocket.chat:X.X.X
 ```
 
 ### Discovering existing releases
@@ -37,6 +37,6 @@ You can select the release you need from our [DockerHub Tags](https://hub.docker
 This is an image that is maintained at Rocket.Chat's own docker repository. It is updated from our `develop` \(untested\) branch, that is, absolute latest, for those who needs to work with latest code.
 
 ```bash
-docker pull rocketchat/rocket.chat:develop
+docker pull registry.rocket.chat/rocketchat/rocket.chat:develop
 ```
 

--- a/installation/docker-containers/docker-compose.md
+++ b/installation/docker-containers/docker-compose.md
@@ -4,7 +4,7 @@ Instead of using the standard Docker commands, you may wish for a bit more autom
 
 * Make sure you have [Docker](https://docs.docker.com/install) and [Docker-compose](https://docs.docker.com/compose/install/) installed and operational.
 * Create `docker-compose.yml` based on [our example](https://github.com/RocketChat/Rocket.Chat/blob/develop/docker-compose.yml).  This is the ONLY file you will need.  You can create this file on your own machine by copy and pasting the content.
-* Edit `image: rocketchat/rocket.chat:latest` to specify which image you wish to use \(see section [Docker Images Available](available-images.md) \)
+* Edit `image: registry.rocket.chat/rocketchat/rocket.chat:latest` to specify which image you wish to use \(see section [Docker Images Available](available-images.md) \)
 * Edit `ROOT_URL` to match your domain name or IP address
 
 You can download our docker-compose.yaml:
@@ -38,7 +38,7 @@ docker-compose up -d hubot
 To update the `rocketchat` docker image to the latest version, you can use the following commands. Your data should not be affected by this, since it's located in the `mongo` image.
 
 ```text
-docker pull rocketchat/rocket.chat:latest
+docker pull registry.rocket.chat/rocketchat/rocket.chat:latest
 docker-compose stop rocketchat
 docker-compose rm rocketchat
 docker-compose up -d rocketchat

--- a/installation/docker-containers/generic-linux/docker-compose.yml
+++ b/installation/docker-containers/generic-linux/docker-compose.yml
@@ -5,7 +5,7 @@ db:
     - ./data/dump:/dump
   command: mongod --smallfiles
 web:
-  image: rocketchat/rocket.chat
+  image: registry.rocket.chat/rocketchat/rocket.chat
   environment:
     - MONGO_URL=mongodb://db:27017/rocketchat
     - ROOT_URL=https://rocketchat.test

--- a/installation/docker-containers/high-availability-install.md
+++ b/installation/docker-containers/high-availability-install.md
@@ -25,7 +25,7 @@ description: Install Rocket.Chat as HA with mongodb replicaset as backend
 
 ```text
 rocketchat:
-    image: rocketchat/rocket.chat:latest
+    image: registry.rocket.chat/rocketchat/rocket.chat:latest
     environment:
         - PORT=3000
         - ROOT_URL=https://chat.domain.de

--- a/installation/docker-containers/systemd.md
+++ b/installation/docker-containers/systemd.md
@@ -68,7 +68,7 @@ Restart=always
 TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill rocketchat
 ExecStartPre=-/usr/bin/docker rm rocketchat
-ExecStartPre=-/usr/bin/docker pull rocketchat/rocket.chat:latest
+ExecStartPre=-/usr/bin/docker pull registry.rocket.chat/rocketchat/rocket.chat:latest
 
 ExecStart=/usr/bin/docker run \
     --name rocketchat \
@@ -79,7 +79,7 @@ ExecStart=/usr/bin/docker run \
     --link mongo:mongo \
     --net=rocketchat_default \
     --expose 3000 \
-    rocketchat/rocket.chat:latest
+    registry.rocket.chat/rocketchat/rocket.chat:latest
 
 ExecStop=-/usr/bin/docker kill rocketchat
 ExecStop=-/usr/bin/docker rm rocketchat

--- a/installation/paas-deployments/aliyun.md
+++ b/installation/paas-deployments/aliyun.md
@@ -144,7 +144,7 @@ This is done only the first time, or when you want to update Rocket.Chat.
 
 ```text
 docker pull mongo
-docker pull rocketchat/rocket.chat
+docker pull registry.rocket.chat/rocketchat/rocket.chat
 ```
 
 ## Start the mongodb database

--- a/installing-and-updating/automation-tools/openshift.md
+++ b/installing-and-updating/automation-tools/openshift.md
@@ -12,7 +12,7 @@ This repository hosts some templates for provision Rocket.Chat in OpenShift.
 * Pull the Rocket.Chat Docker image from Docker Hub and tag/push to the internal OpenShift registry:
 
 ```bash
-docker pull rocketchat/rocket.chat
+docker pull registry.rocket.chat/rocketchat/rocket.chat
 docker tag rocketchat/rocket.chat hub.openshift.rhel-cdk.10.1.2.2.xip.io/openshift/rocket-chat
 docker push hub.openshift.rhel-cdk.10.1.2.2.xip.io/openshift/rocket-chat
 ```

--- a/installing-and-updating/community-supported-installation/windows-10-pro.md
+++ b/installing-and-updating/community-supported-installation/windows-10-pro.md
@@ -25,7 +25,7 @@ db:
   command: mongod --smallfiles --oplogSize 128
 
 rocketchat:
-  image: rocketchat/rocket.chat:latest
+  image: registry.rocket.chat/rocketchat/rocket.chat:latest
   environment:
     - PORT=3000
     - ROOT_URL=http://docker:3000

--- a/installing-and-updating/docker-containers/available-images.md
+++ b/installing-and-updating/docker-containers/available-images.md
@@ -17,7 +17,7 @@ docker pull rocket.chat
 This is an image that is maintained at Rocket.Chat's own docker repository. The release may be from the develop or master branch.
 
 ```bash
-docker pull rocketchat/rocket.chat:latest
+docker pull registry.rocket.chat/rocketchat/rocket.chat:latest
 ```
 
 ## Specific Release Image
@@ -25,7 +25,7 @@ docker pull rocketchat/rocket.chat:latest
 This is an image that is maintained at Rocket.Chat's own docker repository. It is associated with a release build.
 
 ```bash
-docker pull rocketchat/rocket.chat:X.X.X
+docker pull registry.rocket.chat/rocketchat/rocket.chat:X.X.X
 ```
 
 ### Discovering existing releases
@@ -37,6 +37,6 @@ You can select the release you need from our [DockerHub Tags](https://hub.docker
 This is an image that is maintained at Rocket.Chat's own docker repository. It is updated from our `develop` \(untested\) branch, that is, absolute latest, for those who needs to work with latest code.
 
 ```bash
-docker pull rocketchat/rocket.chat:develop
+docker pull registry.rocket.chat/rocketchat/rocket.chat:develop
 ```
 

--- a/installing-and-updating/docker-containers/docker-compose.md
+++ b/installing-and-updating/docker-containers/docker-compose.md
@@ -4,7 +4,7 @@ Instead of using the standard Docker commands, you may wish for a bit more autom
 
 * Make sure you have [Docker](https://docs.docker.com/install) and [Docker-compose](https://docs.docker.com/compose/install/) installed and operational.
 * Create `docker-compose.yml` based on [our example](https://github.com/RocketChat/Rocket.Chat/blob/develop/docker-compose.yml).  This is the ONLY file you will need.  You can create this file on your own machine by copy and pasting the content.
-* Edit `image: rocketchat/rocket.chat:latest` to specify which image you wish to use \(see section [Docker Images Available](available-images.md) \)
+* Edit `image: registry.rocket.chat/rocketchat/rocket.chat:latest` to specify which image you wish to use \(see section [Docker Images Available](available-images.md) \)
 * Edit `ROOT_URL` to match your domain name or IP address
 
 You can download our docker-compose.yaml:
@@ -38,7 +38,7 @@ docker-compose up -d hubot
 To update the `rocketchat` docker image to the latest version, you can use the following commands. Your data should not be affected by this, since it's located in the `mongo` image.
 
 ```text
-docker pull rocketchat/rocket.chat:latest
+docker pull registry.rocket.chat/rocketchat/rocket.chat:latest
 docker-compose stop rocketchat
 docker-compose rm rocketchat
 docker-compose up -d rocketchat

--- a/installing-and-updating/docker-containers/high-availability-install.md
+++ b/installing-and-updating/docker-containers/high-availability-install.md
@@ -25,7 +25,7 @@ description: Install Rocket.Chat as HA with mongodb replicaset as backend
 
 ```text
 rocketchat:
-    image: rocketchat/rocket.chat:latest
+    image: registry.rocket.chat/rocketchat/rocket.chat:latest
     environment:
         - PORT=3000
         - ROOT_URL=https://chat.domain.de

--- a/installing-and-updating/docker-containers/systemd.md
+++ b/installing-and-updating/docker-containers/systemd.md
@@ -68,7 +68,7 @@ Restart=always
 TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill rocketchat
 ExecStartPre=-/usr/bin/docker rm rocketchat
-ExecStartPre=-/usr/bin/docker pull rocketchat/rocket.chat:latest
+ExecStartPre=-/usr/bin/docker pull registry.rocket.chat/rocketchat/rocket.chat:latest
 
 ExecStart=/usr/bin/docker run \
     --name rocketchat \
@@ -79,7 +79,7 @@ ExecStart=/usr/bin/docker run \
     --link mongo:mongo \
     --net=rocketchat_default \
     --expose 3000 \
-    rocketchat/rocket.chat:latest
+    registry.rocket.chat/rocketchat/rocket.chat:latest
 
 ExecStop=-/usr/bin/docker kill rocketchat
 ExecStop=-/usr/bin/docker rm rocketchat

--- a/installing-and-updating/paas-deployments/aliyun.md
+++ b/installing-and-updating/paas-deployments/aliyun.md
@@ -144,7 +144,7 @@ This is done only the first time, or when you want to update Rocket.Chat.
 
 ```text
 docker pull mongo
-docker pull rocketchat/rocket.chat
+docker pull registry.rocket.chat/rocketchat/rocket.chat
 ```
 
 ## Start the mongodb database


### PR DESCRIPTION
This change updates the Docker installation instructions to use the new `registry.rocket.chat` endpoint to pull the `rocketchat/rocket.chat` container. This is part of the rollout described here: https://rocket.chat/blog/product/docker-images-change/

Tagging, uploading, etc, are unaffected and have not been updated, this only affects pulling. 

Happy to add any more explanation in these docs wherever it makes sense, let me know!

cc @geekgonecrazy @johncrisp @Sing-Li 