### PR TITLE
Update supported MongoDB versions

### DIFF
--- a/installing-and-updating/manual-installation/mongo-versions.md
+++ b/installing-and-updating/manual-installation/mongo-versions.md
@@ -1,6 +1,6 @@
 # Supported Mongo Versions
 
-Rocket.Chat currently requires MongoDB from version 3.6 and higher. [Support of MongoDB 3.2 will be removed from Rocket.Chat 2.0.0 and MongoDB 3.4 will be removed from Rocket.Chat 4.x](https://github.com/RocketChat/Rocket.Chat/pull/15199). We recommend using version 3.6.9.
+Rocket.Chat currently requires MongoDB version 3.6 or higher. [Support of MongoDB 3.2 will has been removed from Rocket.Chat 2.0.0 and MongoDB 3.4 has been removed from Rocket.Chat 4.x](https://github.com/RocketChat/Rocket.Chat/pull/15199). We recommend using version 4.2.
 
 **Note** Without mongodb version we can't ensure you are running a compatible version. If you are running your mongodb with auth enabled and an **user different from admin** you may need to grant permissions for this user to check cluster data. You can do it via mongo shell running the following command replacing the string _YOUR\_USER_ by the correct user\'s name:
 


### PR DESCRIPTION
As MongoDB version 3.6 reach end of life it seems to make sense to recommend usage of version 4.2 as it is the most recent version tested in CI (https://github.com/RocketChat/Rocket.Chat/blob/3.16.3/.github/workflows/build_and_test.yml#L196)