### PR TITLE
Bump node version to 12.22.1

### DIFF
--- a/installing-and-updating/manual-installation/updating/README.md
+++ b/installing-and-updating/manual-installation/updating/README.md
@@ -33,7 +33,7 @@ sudo yum install -y gcc-c++ make
 Update the node version required by Rocket.Chat:
 
 ```text
-sudo n install 12.18.4
+sudo n install 12.22.1
 ```
 
 Download Rocket.Chat latest version:


### PR DESCRIPTION
Should be 12.22.1 since rc version 3.14.2, right?
https://github.com/RocketChat/Rocket.Chat/releases/tag/3.14.2