### PR TITLE
Improve Code block style

### DIFF
--- a/contributors/how-can-i-help/documentation/markdown-styleguide.md
+++ b/contributors/how-can-i-help/documentation/markdown-styleguide.md
@@ -597,11 +597,11 @@ Code blocks should be fenced.
 
 **Correct**:
 
-```text
-     ```
-     codeblock.
-     ```
+````
 ```
+codeblock without indentation.
+```
+````
 
 
 


### PR DESCRIPTION
Code block style was rendering correctly on github but not rocker.chat documentation