### PR TITLE
[FIX] Revised the database dump cp command for backup

### DIFF
--- a/quick-start/installing-and-updating/docker-containers/mongodb-mmap-to-wiredtiger-migration.md
+++ b/quick-start/installing-and-updating/docker-containers/mongodb-mmap-to-wiredtiger-migration.md
@@ -39,7 +39,7 @@ Starting with the major release 4.X.Y of Rocket.Chat, MongoDB has to be setup wi
    ```bash
     cd /opt/rocketchat
     docker-compose exec mongo mongodump --archive=/dump/mmap --gzip
-    cp /data/dump/mmap ~/mongo-mmap-dump.gzip
+    cp /opt/rocketchat/data/dump/mmap ~/mongo-mmap-dump.gzip
    ```
 
 2. Stop your existing Rocket.Chat system including all its services \(especially MongoDB\).


### PR DESCRIPTION
Assuming the data dump volume configuration is `- ./data/dump:/dump` on Docker Compose, the host side location would be `/opt/rocketchat/data/dump/` since a `/data` directory is non-existent on Linux. It could also be `cp data/dump/mmap ~/mongo-mmap-dump.gzip` but for the purpose of the complete doc, the proposed change makes it more clear.