### PR TITLE
How to enable systemd template units

### DIFF
--- a/quick-start/installing-and-updating/other-deployment-methods/manual-installation/extras/multiple-instances-to-improve-performance.md
+++ b/quick-start/installing-and-updating/other-deployment-methods/manual-installation/extras/multiple-instances-to-improve-performance.md
@@ -67,7 +67,7 @@ WorkingDirectory=/path.to.rocketchat/rocket.chat
 ExecStart=/usr/local/bin/node /path.to.rocketchat/rocket.chat/bundle/main.js
 
 [Install]
-    WantedBy=rocketchat.service
+WantedBy=multi-user.target
 ```
 
 Start the other Rocket.Chat Services with
@@ -77,8 +77,8 @@ Start the other Rocket.Chat Services with
 If you want to run rocketchat at boot just enable the services with
 
 `systemctl enable rocketchat`
-
-The other Services will be enable since they are "WantedBy"=RocketChat.service
+or
+`systemctl enable rocketchat@3001`
 
 ### Ensure nodes can communicate
 


### PR DESCRIPTION
Hi,

Reading the documentation, this text seemed to be logically inconsistent.  

```
The other Services will be enable since they are "WantedBy"=RocketChat.service
```
Imagine a user wants to enable services on ports 3002, 3003, and 3004.  Since these are systemd "templates", where will these numbers (3002, 3003, 3004) be stored and remembered later?  The answer, I think, is they will only be retained if you type a command such as 

```
systemctl enable rocketchat@3002
```

If that's the case, then "The services _may be_ enabled".   But not "the other services _will be_ enabled".

From https://unix.stackexchange.com/questions/506347/why-do-most-systemd-examples-contain-wantedby-multi-user-target

"However, WantedBy is separate from the enabled/disabled state: so in another sense, it's sort of a "preset": it determines under what conditions the automatic start may happen, but only when the service is enabled in the first place."

