### PR TITLE
client_max_body_size setting in nginx

### DIFF
--- a/quick-start/installing-and-updating/other-deployment-methods/manual-installation/extras/multiple-instances-to-improve-performance.md
+++ b/quick-start/installing-and-updating/other-deployment-methods/manual-installation/extras/multiple-instances-to-improve-performance.md
@@ -141,6 +141,7 @@ server {
         proxy_set_header X-Nginx-Proxy true;
 
         proxy_redirect off;
+        client_max_body_size 0;
     }
 }
 ```


### PR DESCRIPTION
Hi,

From https://github.com/RocketChat/Rocket.Chat/issues/13351 it was necessary to set `client_max_body_size 0;` to fix the bug 
"Failed_To_upload_Import_File" for Slack Import.      I encountered the issue and it's also corroborated by other users in the discussion.   

"By default, NGINX® has a upload limit of 1 MB per file. By editing client_max_body_size, you adjust the file upload size."




