### PR TITLE
Fix documentation: typos in app guides

### DIFF
--- a/guides/app-guides/omnichannel-apps/dialogflow-app/dialogflow-app-configuration/delete-dialogflow-app.md
+++ b/guides/app-guides/omnichannel-apps/dialogflow-app/dialogflow-app-configuration/delete-dialogflow-app.md
@@ -2,7 +2,7 @@
 
 To delete the Dialogflow app from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Dialogflow**
+Goto **Administration>Apps>Installed>Dialogflow**
 
 Hit **Uninstall**
 

--- a/guides/app-guides/omnichannel-apps/facebook-app/facebook-app-configuration/delete-facebook-app.md
+++ b/guides/app-guides/omnichannel-apps/facebook-app/facebook-app-configuration/delete-facebook-app.md
@@ -2,7 +2,7 @@
 
 To delete Facebook app from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Facebook Messenger**
+Goto **Administration>Apps>Installed>Facebook Messenger**
 
 Hit **Uninstall**
 

--- a/guides/app-guides/omnichannel-apps/facebook-app/facebook-app-configuration/facebook-app-authentication.md
+++ b/guides/app-guides/omnichannel-apps/facebook-app/facebook-app-configuration/facebook-app-authentication.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Authorise Omni-Gateway to send and receive Facebook messages on behalf your
+  Authorize Omni-Gateway to send and receive Facebook messages on behalf your
   account.
 ---
 

--- a/guides/app-guides/omnichannel-apps/instagram-direct/instagram-direct-configuration/delete-instagram-direct.md
+++ b/guides/app-guides/omnichannel-apps/instagram-direct/instagram-direct-configuration/delete-instagram-direct.md
@@ -2,7 +2,7 @@
 
 To delete Instagram Direct from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Instagram Direct**
+Goto **Administration>Apps>Installed>Instagram Direct**
 
 Hit **Uninstall**
 

--- a/guides/app-guides/omnichannel-apps/rasa-app/rasa-app-configuration/delete-rasa-app.md
+++ b/guides/app-guides/omnichannel-apps/rasa-app/rasa-app-configuration/delete-rasa-app.md
@@ -2,7 +2,7 @@
 
 To delete the Dialogflow app from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Rasa**
+Goto **Administration>Apps>Installed>Rasa**
 
 Hit **Uninstall**
 

--- a/guides/app-guides/omnichannel-apps/salesforce-crm-integration/salesforce-crm-configuration/delete-salesforce-crm-integration.md
+++ b/guides/app-guides/omnichannel-apps/salesforce-crm-integration/salesforce-crm-configuration/delete-salesforce-crm-integration.md
@@ -2,7 +2,7 @@
 
 To delete the Dialogflow app from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Dialogflow**
+Goto **Administration>Apps>Installed>Dialogflow**
 
 Hit **Uninstall**
 

--- a/guides/app-guides/omnichannel-apps/sms.md
+++ b/guides/app-guides/omnichannel-apps/sms.md
@@ -54,7 +54,7 @@ Make sure the action type selected above is _`Webhook`_ and the method is _`HTTP
 
 After getting all the settings on your Twilio Programmable Messaging number ready, it's time to connect it with your Rocket.Chat workspace.
 
-* Open up Rocket.Chat and go to **Administration** > **Setings** > **SMS**
+* Open up Rocket.Chat and go to **Administration** > **Settings** > **SMS**
 * Select Twilio and the **service** type, then move down to the Twilio section and fill in your Twilio credentials. This can be gotten from the [Twilio console](https://console.twilio.com/)
 * With that done, **enable** the service and hit **Save changes**
 

--- a/guides/app-guides/omnichannel-apps/telegram-app/telegram-app-configuration/delete-telegram-app.md
+++ b/guides/app-guides/omnichannel-apps/telegram-app/telegram-app-configuration/delete-telegram-app.md
@@ -2,7 +2,7 @@
 
 To Delete Telegram app from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Telegram**
+Goto **Administration>Apps>Installed>Telegram**
 
 Click **Uninstall**.
 

--- a/guides/app-guides/omnichannel-apps/twitter-app/twitter-app-configuration/delete-twitter-app.md
+++ b/guides/app-guides/omnichannel-apps/twitter-app/twitter-app-configuration/delete-twitter-app.md
@@ -2,7 +2,7 @@
 
 To delete the Twitter app from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Facebook Messenger**
+Goto **Administration>Apps>Installed>Facebook Messenger**
 
 Hit **Uninstall**
 

--- a/guides/app-guides/omnichannel-apps/twitter-app/twitter-app-configuration/twitter-app-authentication.md
+++ b/guides/app-guides/omnichannel-apps/twitter-app/twitter-app-configuration/twitter-app-authentication.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Authorise Omni-Gateway to send and receive Twitter messages on behalf your
+  Authorize Omni-Gateway to send and receive Twitter messages on behalf your
   account.
 ---
 

--- a/guides/app-guides/omnichannel-apps/whatsapp/whatsapp-configuration/delete-whatsapp.md
+++ b/guides/app-guides/omnichannel-apps/whatsapp/whatsapp-configuration/delete-whatsapp.md
@@ -2,7 +2,7 @@
 
 To delete Whatsapp from your workspace:
 
-Goto **Adminisitration>Apps>Installed>Instagram Direct**
+Goto **Administration>Apps>Installed>Instagram Direct**
 
 Hit **Uninstall**
 

--- a/guides/app-guides/poll-plus/guides/live-poll.md
+++ b/guides/app-guides/poll-plus/guides/live-poll.md
@@ -2,7 +2,7 @@
 
 Live Polls are an array of regular polls. A Live Poll is a **multi-question, timed** poll.
 
-Live Polls can be trigerred with the `/poll live <number of polls>` command. Here `<number of polls>` denotes the number of polls you want to be included within the Live Poll.
+Live Polls can be triggered with the `/poll live <number of polls>` command. Here `<number of polls>` denotes the number of polls you want to be included within the Live Poll.
 
 Each poll within a Live Poll has a time limit to vote upon after which the current Poll ends and the next one is posted. Poll creators can also click on the **“Next Poll”** button to trigger a pre-scheduled finish of the current Poll.
 

--- a/guides/app-guides/poll-plus/guides/mixed-visibility-polls.md
+++ b/guides/app-guides/poll-plus/guides/mixed-visibility-polls.md
@@ -2,7 +2,7 @@
 
 In addition to the open and confidential visibilities which affects all Poll options, you can also set the visibility of specific Poll options to be confidential and the remaining to be open.
 
-To enable Mixed Visiblity, set the visibility to **"Mixed Visibility Vote"** within the Poll creation modal.
+To enable Mixed Visibility, set the visibility to **"Mixed Visibility Vote"** within the Poll creation modal.
 
 ![](../../../../.gitbook/assets/poll_mixed_visibility_1.jpg)
 

--- a/guides/app-guides/trello.md
+++ b/guides/app-guides/trello.md
@@ -13,21 +13,21 @@ With this app, you will be able to receive notifications about your Trello activ
 {% hint style="warning" %}
 It is required you have the following to successfully setup the Trello app
 
-* A publicly accesible Rocket.Chat server
+* A publicly accessible Rocket.Chat server
 * A Trello account with some boards to be watched.
 {% endhint %}
 
 To install the Trello Rocket.Chat App,
 
 * Go to **Administration > Marketplace**
-* Search for the **Tello** app and click on the item
-* Click **Install** and accept the needed permisions
+* Search for the **Trello** app and click on the item
+* Click **Install** and accept the needed permissions
 
 ![](<../../.gitbook/assets/image (48) (2).png>)
 
 You should see an interface with the app details showing you have installed it.
 
-A direct message is then receieved from the `trello.bot` to assist you with the setup of the app
+A direct message is then received from the `trello.bot` to assist you with the setup of the app
 
 ![](<../../.gitbook/assets/image (109) (2).png>)
 


### PR DESCRIPTION
**Corrected typos:**
```
Adminisitration -> Administration
accesible -> accessible
Tello -> Trello
permisions -> permissions
receieved -> received
Authorise -> Authorize
trigerred -> triggered
Visiblity -> Visibility
```