### PR TITLE
Fix documentation: typos in the documentation

### DIFF
--- a/contributors/annual-contribution-programs/google-season-of-docs/google-season-of-docs-2022.md
+++ b/contributors/annual-contribution-programs/google-season-of-docs/google-season-of-docs-2022.md
@@ -40,7 +40,7 @@ Rocket.Chat supports over 59 local languages. Rocket.Chat's community interacts 
 
 ### The problem
 
-Rocket.Chat can be extended through apps. Apps are considerably easier to code than modifying the large Rocket.Chat code base. But we are seriously lacking on documation for Apps developers.
+Rocket.Chat can be extended through apps. Apps are considerably easier to code than modifying the large Rocket.Chat code base. But we are seriously lacking on documentation for Apps developers.
 
 New app builders have a hard time navigating our existing meager documentation. There is a lack of details and current contents are difficult to understand. This makes building an app a very time consuming activity and causes developers to get frustrated or even abandon their projects.
 

--- a/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2017.md
+++ b/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2017.md
@@ -43,7 +43,7 @@ Please keep monitoring this page for the latest Rocket.Chat GSoC 2017 updates.
 
 #### Coding has started
 
-June is finally upon us. All of our GSoC students who have had prior apprenticeship or other engagements are now free of their obligations, and have started to code for Rocket.Chat full time. The _commmunity bonding_ period has come and gone smoothly, with the mingling between our students and the core team on the 24 x 7 community chat server, on GitHub, via email, or at our weekly scheduled team video-conference. Many of our students have also made friends with our extended community - helping them and exchanging ideas for their projects.
+June is finally upon us. All of our GSoC students who have had prior apprenticeship or other engagements are now free of their obligations, and have started to code for Rocket.Chat full time. The _community bonding_ period has come and gone smoothly, with the mingling between our students and the core team on the 24 x 7 community chat server, on GitHub, via email, or at our weekly scheduled team video-conference. Many of our students have also made friends with our extended community - helping them and exchanging ideas for their projects.
 
 In fact, due to their overwhelming enthusiasm, most of our GSoC students have started coding even before the beginning of June. Here are some of the most recent contributions \(of many!\) to Rocket.Chat by our new team of GSoC recruits:
 

--- a/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2018.md
+++ b/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2018.md
@@ -111,7 +111,7 @@ Interested students are also encouraged to interact with our contributor communi
 ### NextCloud as a Storage Provider
 
 * **Mentors:** @guilherme.gazzo, @bjoern.schiessle \(Nextcloud Guest Mentor\)
-* **Description:** \(1\) Enabling Rocket.Chat server adminstrator to use an NextCloud instance for storage of upload. \(2\) Within Rocket.Chat client user interface, allow access to the contents on a user's NextCloud instance
+* **Description:** \(1\) Enabling Rocket.Chat server administrator to use an NextCloud instance for storage of upload. \(2\) Within Rocket.Chat client user interface, allow access to the contents on a user's NextCloud instance
 * **Desirable Skills:** Familiarity with both Rocket.Chat and NextCloud development.
 
 ### Snap Crafting

--- a/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2019.md
+++ b/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2019.md
@@ -18,13 +18,13 @@ First evaluation has completed! Coding continues at a feverish pace. Progress ha
 
 #### Update on May 28, 2019
 
-Coding has begun! This year continues to be the most active and productive GSoC year at Rocket.Chat. During the bonding period, our students continued to assist community in public channels, interact with core team, contribute to bug fixes and documenation updates. They have also worked with their mentors to add detailed schedule to their proposal, reflecting measurable goals/milestones. Coding and detailed design work have started across all active projects. In addition, we are happy to welcome a team of community mentors from Credit Suisse Singapore, already well experienced with our core and native mobile code bases, to assist us this season.
+Coding has begun! This year continues to be the most active and productive GSoC year at Rocket.Chat. During the bonding period, our students continued to assist community in public channels, interact with core team, contribute to bug fixes and documentation updates. They have also worked with their mentors to add detailed schedule to their proposal, reflecting measurable goals/milestones. Coding and detailed design work have started across all active projects. In addition, we are happy to welcome a team of community mentors from Credit Suisse Singapore, already well experienced with our core and native mobile code bases, to assist us this season.
 
 Unfortunately, during this time, we had to remove one student from the program due to extended inactivity.
 
 #### Update on May 8, 2019
 
-2019 is an incredible year for GSoC at Rocket.Chat. Thanks to the ethusiastic early support from students and community \(mentors\), Google has graciously granted us **SEVENTEEN** project slots. This far surpasses any record from prior years. As a result, we are delighted to welcome these 17 active community members to work with us during the GSoC 2019 season:
+2019 is an incredible year for GSoC at Rocket.Chat. Thanks to the enthusiastic early support from students and community \(mentors\), Google has graciously granted us **SEVENTEEN** project slots. This far surpasses any record from prior years. As a result, we are delighted to welcome these 17 active community members to work with us during the GSoC 2019 season:
 
 | Student | Project | Mentors |
 | :--- | :--- | :--- |
@@ -48,7 +48,7 @@ Unfortunately, during this time, we had to remove one student from the program d
 
 It was a very difficult decision for many mentors to select from the large number of highly qualified students \(we were able to engage the students early on in the GSoC cycle with open source contributions via the [GSoC Leaderboard](https://gsoc.rocket.chat/) \).
 
-Some high calibre open source contributors were not selected for GSoC; to accomodate these exceptional students, our community member [Viasat](https://www.viasat.com/) has agreed to sponsor an additional FOUR projects this season. Rocket.Chat has in addition sponsored ONE qualified student with special circumstances to work with us for the term.
+Some high calibre open source contributors were not selected for GSoC; to accommodate these exceptional students, our community member [Viasat](https://www.viasat.com/) has agreed to sponsor an additional FOUR projects this season. Rocket.Chat has in addition sponsored ONE qualified student with special circumstances to work with us for the term.
 
 | Student | Sponsored Project |
 | :--- | :--- |
@@ -58,7 +58,7 @@ Some high calibre open source contributors were not selected for GSoC; to accomo
 | SShi-qi Mei | Performance optimizations for ReactNative Client |
 | Prajval Raval | Google Action for Google Home and Server-side improvements to support VUI |
 
-This, in combination, allowed us to accomodate a total of **TWENTY TWO** ethusiastic students this summer season.
+This, in combination, allowed us to accommodate a total of **TWENTY TWO** enthusiastic students this summer season.
 
 All students and mentors are now busy mutually bonding and with our core team and greater community. Each mentor is also working with his/her student on refining the weekly and monthly milestones/deliverables within the proposal to better reflect achievable project objectives as well as making them measurable for the monthly evaluations. Meanwhile, all our students are continuing to contribute to the Rocket.Chat open source project\(s\) as they have been doing since the start of the GSoC 2019 cycle.
 

--- a/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2020.md
+++ b/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2020.md
@@ -74,7 +74,7 @@ All students and mentors are now busy mutually bonding and with our core team an
 
 #### Update March 31st, 2020
 
-First, we would like to thank all GSoC 2020 students for their ethusiastic support for Rocket.Chat. This year we have received a total of **86** proposals, including **81** final proposals. In the final pool, there are 13 proposals that are spam, without content, or not related to our projects.
+First, we would like to thank all GSoC 2020 students for their enthusiastic support for Rocket.Chat. This year we have received a total of **86** proposals, including **81** final proposals. In the final pool, there are 13 proposals that are spam, without content, or not related to our projects.
 
 Over the next month, our mentors will be reviewing the received proposals. Google Summer of Code will be announcing the selected projects and students on May 4th, 2020. Please see [GSoC timeline](google-summer-of-code-2020.md#timeline) for more details.
 
@@ -92,7 +92,7 @@ The leaderboard project **itself** is open source, created and maintained by our
 
 We have recnetly arranged for the TOP 8 student contributors to meet one on one with Rocket.Chat's project lead Gabriel Engel and great remote fun was had by all.
 
-Mentoring interest from core team has been reduced this year, while community mentor participation is at an all time high. Proposals for projects are streaming steadily in since application open, the volume of incoming proposals is reduced compared to prior year - but the percentage of high quality propsals has increased.
+Mentoring interest from core team has been reduced this year, while community mentor participation is at an all time high. Proposals for projects are streaming steadily in since application open, the volume of incoming proposals is reduced compared to prior year - but the percentage of high quality proposals has increased.
 
 #### About GSoC 2020
 
@@ -119,7 +119,7 @@ Interested students are also encouraged to interact with our contributor communi
 ### Advanced Rocket.Chat administrators and operations toolkit
 
 * **Mentors**: [@diego.sampaio](https://open.rocket.chat/direct/diego.sampaio), [@sing.li](https://open.rocket.chat/direct/sing.li)
-* **Description**: Administration and management of a Rocket.Chat server is a very complex task, especially for servers that are utilized by thousdands of users on a daily basis.  There exists many administrative and operational activities that require access to the system in ways that are not currently supported by our Administrative dashboard.  This project creates small, standalone tools, to address this need. These tools will be immediately useful for anyone operating one-or-more large Rocket.Chat server(s) worldwide.
+* **Description**: Administration and management of a Rocket.Chat server is a very complex task, especially for servers that are utilized by thousands of users on a daily basis.  There exists many administrative and operational activities that require access to the system in ways that are not currently supported by our Administrative dashboard.  This project creates small, standalone tools, to address this need. These tools will be immediately useful for anyone operating one-or-more large Rocket.Chat server(s) worldwide.
 * **Desirable Skills**: Familiarity with nodeJS fullstack webapp development. Experience with ReactJS or Vue.js ideal.  Must have database skills, ideally MongoDB.
 
 ### Download Manager on Desktop App

--- a/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2022.md
+++ b/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2022.md
@@ -49,7 +49,7 @@ We are also planning a virtual conference at the end of the GSoC term - named GS
 | Standalone Desktop Messaging cross-platforms Applet                | [https://github.com/RocketChat/SlimDesktopApp](https://github.com/RocketChat/SlimDesktopApp)                                                             |
 | Weekly Video Meeting and Archive App - BigBlueButton + Rocket.Chat | [https://github.com/RocketChat/Apps.BigBlueButton](https://github.com/RocketChat/Apps.BigBlueButton)                                                     |
 | New Emoji Picker for Mobile Client                                 | [https://github.com/RocketChat/Rocket.Chat.ReactNative](https://github.com/RocketChat/Rocket.Chat.ReactNative)                                           |
-| Rocket.Chat for Virtual Conferences - Eventyay integration         | [https://github.com/RocketChat/RC4Conferences](https://github.com/RocketChat/RC4Conferences)                                                             |
+| Rocket.Chat for Virtual Conferences - Eventual integration         | [https://github.com/RocketChat/RC4Conferences](https://github.com/RocketChat/RC4Conferences)                                                             |
 | Rocket.Chat Golang SDK                                             | [https://github.com/RocketChat/Rocket.Chat.Go.SDK](https://github.com/RocketChat/Rocket.Chat.Go.SDK)                                                     |
 | Figma App ( Rocket.Chat Integration )                              | [https://github.com/RocketChat/Apps.Figma](https://github.com/RocketChat/Apps.Figma)                                                                     |
 | ClickUp App for Rocket.Chat                                        | [https://github.com/RocketChat/Apps.ClickUp](https://github.com/RocketChat/Apps.ClickUp)                                                                 |
@@ -149,7 +149,7 @@ There is already an [n8n node ](https://n8n.io/integrations/n8n-nodes-base.rocke
 
 **Mentor(s):** Rohan Lekhwani
 
-**Description:** Create a ready-to-go easy to embed mini-chat React component. This component should be configurable to use any public channel on a Rocket.Chat server. Authentication should be flexibly configurable to existing Rocket.Chat server token, or via an independent IDM or auth service. The challenge here is to create a futuristic full-stack component that bundles tightly coupled backend behaviours with standard front-end ReactJS components (from Rocket.Chat Fuselage ReactJS library) - creating an amazing developer experience when developing In-App Chat applications.\
+**Description:** Create a ready-to-go easy to embed mini-chat React component. This component should be configurable to use any public channel on a Rocket.Chat server. Authentication should be flexibly configurable to existing Rocket.Chat server token, or via an independent IDM or auth service. The challenge here is to create a futuristic full-stack component that bundles tightly coupled backend behaviors with standard front-end ReactJS components (from Rocket.Chat Fuselage ReactJS library) - creating an amazing developer experience when developing In-App Chat applications.\
 **Desired Skills:** ReactJS component creation experience, understanding of Rocket.Chat server internals
 
 **Goals/Deliverables:** Standlone mini-chat React component that can be easily installed into any ReactJS based web app
@@ -189,7 +189,7 @@ There is already an [n8n node ](https://n8n.io/integrations/n8n-nodes-base.rocke
 
 **Mentor(s):** Cauê Felchar, Aaron Ogle
 
-**Description:** Golang module to enable any Go packge to talk to a Rocket.Chat server with ease, making it possible to create from custom clients to bots.
+**Description:** Golang module to enable any Go package to talk to a Rocket.Chat server with ease, making it possible to create from custom clients to bots.
 
 **Goals/Deliverables:**
 

--- a/legal/master-service-agreement-for-professional-services.md
+++ b/legal/master-service-agreement-for-professional-services.md
@@ -54,7 +54,7 @@ We may update this Agreement and we will let you know when we do through the Ser
 
 **"Rocket.Chat Contract Manager"** means a primary contact with respect to this Agreement and who will have the authority to act on behalf of Service Provider in connection with matters pertaining to this Agreement
 
-**"Rocke.Chat Personnel"** means all employees and Permitted Subcontractors, if any, engaged by Rocket.Chat to perform the Services.
+**"Rocket.Chat Personnel"** means all employees and Permitted Subcontractors, if any, engaged by Rocket.Chat to perform the Services.
 
 **"Services"** mean the professional and other services to be provided by Service Provider under this agreement, as described in more detail in a Statement of Work, and Service Provider's obligations under this Agreement.
 

--- a/quick-start/deploying-rocket.chat/other-deployment-methods/manual-installation/rocket.chat-in-centos.md
+++ b/quick-start/deploying-rocket.chat/other-deployment-methods/manual-installation/rocket.chat-in-centos.md
@@ -71,7 +71,7 @@ cd /tmp/bundle/programs/server && npm installs
 ```
 
 ```bash
-sudo mv /tmp/bundle /opt/Rocket.Chath
+sudo mv /tmp/bundle /opt/Rocket.Chat
 ```
 
 ## Configure the Rocket.Chat service
@@ -103,7 +103,7 @@ WantedBy=multi-user.target
 EOFash
 ```
 
-Open the Rocket.Chat service file just created (`/usr/lib/systemd/system/rocketchat.service`) using sudo and your favourite text editor, and change the ROOT\_URL environmental variable to reflect the URL you want to use for accessing the server (optionally change MONGO\_URL, MONGO\_OPLOG\_URL and PORT):
+Open the Rocket.Chat service file just created (`/usr/lib/systemd/system/rocketchat.service`) using sudo and your favorite text editor, and change the ROOT\_URL environmental variable to reflect the URL you want to use for accessing the server (optionally change MONGO\_URL, MONGO\_OPLOG\_URL and PORT):
 
 ```bash
 MONGO_URL=mongodb://localhost:27017/rocketchat?replicaSet=rs01

--- a/quick-start/installing-and-updating/introduction/choosing-a-deployment-method.md
+++ b/quick-start/installing-and-updating/introduction/choosing-a-deployment-method.md
@@ -43,7 +43,7 @@ This is something that’s ignored very frequently but should be considered for 
 
 This scorecard shows a rating(on 05) of each deployment method against each consideration.
 
-|                         |                    Docker                   |                    Snaps                   |                                                                           One Click Deploment                                                                          |
+|                         |                    Docker                   |                    Snaps                   |                                                                           One Click Deployment                                                                          |
 | ----------------------- | :-----------------------------------------: | :----------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | **Scalability**         | <mark style="color:blue;">**`3.75`**</mark> |  <mark style="color:red;">**`1.0`**</mark> |                                                                <mark style="color:red;">**`2.0`**</mark>                                                               |
 | **Ease of Deployment**  | <mark style="color:blue;">**`3.75`**</mark> | <mark style="color:blue;">**`4.5`**</mark> |                                                               <mark style="color:blue;">**`5.0`**</mark>                                                               |


### PR DESCRIPTION
Corrected typos:

documation -> documentation
commmunity -> community
adminstrator -> administrator
ethusiastic -> enthusiastic
accomodate -> accommodate
propsals -> proposals
thousdands -> thousands
Eventyay -> Eventual
behaviours -> behaviors
packge -> package
Rocke.Chat -> Rocket.Chat
Rocket.Chath -> Rocket.Chat
favourite -> favorite
Deploment -> Deployment

