### PR TITLE
correct Omnichannel mentions

### DIFF
--- a/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2022.md
+++ b/contributors/annual-contribution-programs/google-summer-of-code/google-summer-of-code-2022.md
@@ -166,7 +166,7 @@ There is already an [n8n node ](https://n8n.io/integrations/n8n-nodes-base.rocke
 
 **Mentor(s):** Frank Dase, Duda Nogueira
 
-**Description:** Botpress is a popular open source framework for creation and execution of chatbots. This project extends a existing community-contributed Botpress connector to facilitate deployment of Botpress chatbots and omnichannel bots. Focus here will include - better rich UI/UX / interaction support for bots and ability to run multiple instances of multiple bots.\
+**Description:** Botpress is a popular open source framework for creation and execution of chatbots. This project extends a existing community-contributed Botpress connector to facilitate deployment of Botpress chatbots and Omnichannel bots. Focus here will include - better rich UI/UX / interaction support for bots and ability to run multiple instances of multiple bots.\
 **Desired Skills:** Javascript and Typescript development. Keen interest in Bots and Chatbots.
 
 **Goals/Deliverables:** A Rocket.Chat App as a Botpress connector. A couple of example chatbots (running in a channel, and running in omnichannel) plus documentation.
@@ -240,7 +240,7 @@ There is already an [n8n node ](https://n8n.io/integrations/n8n-nodes-base.rocke
 
 **Description:** This project investigates and implements a new and "native" identity verification mechanism for Omnichannel end-users, such as Live Chat visitors who, depending on the use case, have to provide personal data like email addresses, etc. [Rocket.Chat](http://rocket.chat) already has in place a similar confirmation mechanism for user verification, such as 2FA, email, etc. The contributor will have the freedom to propose ideas and design the best solution for the problem described.
 
-**Desired Skills:** Familiarity with JavaScript development. Good understanding of the architecture of Rocket.Chat's omnichannel implementation.
+**Desired Skills:** Familiarity with JavaScript development. Good understanding of the architecture of Rocket.Chat's Omnichannel implementation.
 
 **Project Duration:** 175 hours. (Medium)
 

--- a/guides/administration/admin-panel/connectivity-services.md
+++ b/guides/administration/admin-panel/connectivity-services.md
@@ -3,7 +3,7 @@
 Rocket.Chat Connectivity Services gives you access to connect your self-hosted workplace to Rocket.Chat cloud. Connecting your workplace to the cloud gives you access to interact with services like
 
 * Mobile push notifications gateway
-* Live Chat omnichannel proxy
+* Live Chat Omnichannel proxy
 * OAuth proxy for social network
 * Apps Marketplace
 

--- a/guides/administration/admin-panel/info.md
+++ b/guides/administration/admin-panel/info.md
@@ -84,7 +84,7 @@ Clear the old license code and paste the new license code then hit the **Apply l
   * **Total Private Groups**: Total number of private groups on the server
   * **Total Direct Message Rooms**: Total number of Direct Messages created on the server.
   * **Total Discussions**: Total number of discussions
-  * **Total Omnichannel Rooms**: Total number of omnichannel rooms.
+  * **Total Omnichannel Rooms**: Total number of Omnichannel rooms.
 * **Messages**
   * **Total Messages**: Total messages sent and received on the server.
   * **Total Threads**: The total number of threads on the server.

--- a/guides/administration/admin-panel/settings/omnichannel-admins-guide/README.md
+++ b/guides/administration/admin-panel/settings/omnichannel-admins-guide/README.md
@@ -28,8 +28,8 @@ Now the admin will have access to _**Omnichannel Panel Settings**_ through a new
 
 1. Enable Omnichannel on your Rocket.Chat instance
 2. Enable/Disable request comment from the agent when closing a conversation
-3. Enable/Disable acceptance of new omnichannel requests when the agent is idle
-4. Enable/Disable continuous sound notification for new omnichannel room/conversation
+3. Enable/Disable acceptance of new Omnichannel requests when the agent is idle
+4. Enable/Disable continuous sound notification for new Omnichannel room/conversation
 5. Enable/Disable file uploads in the Live Chat widget
 6. Enable/Disable asking the visitor if they would like a transcript of the conversation.
 7. Enter the message to show when asking for a transcript.
@@ -38,7 +38,7 @@ Now the admin will have access to _**Omnichannel Panel Settings**_ through a new
 
 ### Business Hour
 
-The feature turns on the omnichannel toggle for the set business hours automatically. And you will be able to receive omnichannel conversations after. The toggle will be turned off during off-hours. The enterprise workspaces can set up multiple business hours according to different time zones and their business needs. Community workspaces can only set up one set of business hours.
+The feature turns on the Omnichannel toggle for the set business hours automatically. And you will be able to receive Omnichannel conversations after. The toggle will be turned off during off-hours. The enterprise workspaces can set up multiple business hours according to different time zones and their business needs. Community workspaces can only set up one set of business hours.
 
 1. Enable business hours
 2. Choose multiple business hours according to your enterprise needs
@@ -126,7 +126,7 @@ Routing allows you to define the behavior of your Live Chat queues.
 Detail of every setting is listed below:
 
 1. Select your preferred routing method (Please refer to [this](https://docs.rocket.chat/guides/omnichannel-guides/omnichannel/livechat-queues) article for information on types of routing methods used in rocket chat)
-2. Enable acceptance of incoming omnichannel requests even if there are no online agents if you want
+2. Enable acceptance of incoming Omnichannel requests even if there are no online agents if you want
 3. Enable if you want the routing system to attempt to find a bot agent before addressing new conversations to a human agent
 4. Set the limit of **Max number of items displayed in the queue** if you want
 5. Enable if you want to show the Live Chat queue to all the agents

--- a/guides/administration/admin-panel/settings/omnichannel-admins-guide/queue-types-routing-algorithm.md
+++ b/guides/administration/admin-panel/settings/omnichannel-admins-guide/queue-types-routing-algorithm.md
@@ -1,6 +1,6 @@
 # Queue Types (Routing Algorithm)
 
-There are the following types of queues in Rocket.Chat omnichannel solutions:
+There are the following types of queues in Rocket.Chat Omnichannel solutions:
 
 * [Auto Selection \[default\]](queue-types-routing-algorithm.md#auto-selection)
 * [Manual Selection](queue-types-routing-algorithm.md#manual-selection)
@@ -30,7 +30,7 @@ When the agent clicks on the incoming Live Chat, the system will show the previe
 
 You can use an `External Service` to integrate your own agent routing rule into Live Chat.
 
-Once you set up the `External Service` as the Live Chat routing method, you must define the `External Queue Service URL` and `Secret Token` settings in the omnichannel admin panel.
+Once you set up the `External Service` as the Live Chat routing method, you must define the `External Queue Service URL` and `Secret Token` settings in the Omnichannel admin panel.
 
 Rocket.Chat will send a GET request to the `External Queue Service URL` and the setting `Secret Token` is sent as a header `X-RocketChat-Secret-Token`, so you can validate if the request came from the Rocket.Chat.
 

--- a/guides/app-guides/omnichannel-apps/README.md
+++ b/guides/app-guides/omnichannel-apps/README.md
@@ -10,7 +10,7 @@ Omnichannel apps give consumers a choice to engage with you on their favorite ch
 * Facebook Messenger
 
 {% hint style="success" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="sms.md" %}

--- a/guides/app-guides/omnichannel-apps/dialogflow-app/README.md
+++ b/guides/app-guides/omnichannel-apps/dialogflow-app/README.md
@@ -7,10 +7,10 @@ description: >-
 
 # Dialogflow App
 
-Using Rocket.Chat and the Dialogflow Chatbot platform integration, you can set up and train your chatbot to respond to any query it's been trained for and configure it to act as an omnichannel agent.
+Using Rocket.Chat and the Dialogflow Chatbot platform integration, you can set up and train your chatbot to respond to any query it's been trained for and configure it to act as an Omnichannel agent.
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 Please follow this [guide](https://cloud.google.com/dialogflow/es/docs/quick/setup) to find all required setup steps to start using Dialogflow.

--- a/guides/app-guides/omnichannel-apps/dialogflow-app/dialogflow-app-configuration/README.md
+++ b/guides/app-guides/omnichannel-apps/dialogflow-app/dialogflow-app-configuration/README.md
@@ -16,7 +16,7 @@ Following are the settings available:
 
 ![](<../../../../../.gitbook/assets/2022-01-15\_19-13-30 (1) (1) (1).png>)
 
-3\. Suppose the omnichannel end-user asks something that the bot is not trained to answer and fails. **Fallback Responses Limit** defines how many failures of the conversation should be forwarded to a human agent.
+3\. Suppose the Omnichannel end-user asks something that the bot is not trained to answer and fails. **Fallback Responses Limit** defines how many failures of the conversation should be forwarded to a human agent.
 
 4\. Upon bot-to-live agent handover, the visitor is transferred to **Target Department for Handover.**
 

--- a/guides/app-guides/omnichannel-apps/email-inboxes/README.md
+++ b/guides/app-guides/omnichannel-apps/email-inboxes/README.md
@@ -5,7 +5,7 @@ description: Omnichannel Integration between Rocket.Chat and Email.
 # Email Inboxes
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="email-inbox-admin-guide.md" %}

--- a/guides/app-guides/omnichannel-apps/email-inboxes/email-inbox-admin-guide.md
+++ b/guides/app-guides/omnichannel-apps/email-inboxes/email-inbox-admin-guide.md
@@ -1,6 +1,6 @@
 # Email Inbox Admin Guide
 
-As an omnichannel administrator, you can configure and manage omnichannel email inboxes or email accounts for the email channels.
+As an Omnichannel administrator, you can configure and manage Omnichannel email inboxes or email accounts for the email channels.
 
 To set up a new email inbox:
 

--- a/guides/app-guides/omnichannel-apps/email-inboxes/email-inbox-agent-guide.md
+++ b/guides/app-guides/omnichannel-apps/email-inboxes/email-inbox-agent-guide.md
@@ -6,9 +6,9 @@ description: >-
 
 # Email Inbox Agent Guide
 
-Once an email is part of a channel, your contacts can send emails to it to start a conversation. It will appear inside Rocket.Chat just like any other omnichannel Live Chat conversation. When you reply to an email message that has been sent to you, it will appear just like any other email in your contact’s inbox.
+Once an email is part of a channel, your contacts can send emails to it to start a conversation. It will appear inside Rocket.Chat just like any other Omnichannel Live Chat conversation. When you reply to an email message that has been sent to you, it will appear just like any other email in your contact’s inbox.
 
-As soon as your contact sends an email to the registered email address, it will appear in the queue just like any other omnichannel conversation, as shown below:
+As soon as your contact sends an email to the registered email address, it will appear in the queue just like any other Omnichannel conversation, as shown below:
 
 ![](<../../../../.gitbook/assets/image (217).png>)
 
@@ -47,7 +47,7 @@ They are invited to the channel, as shown below:
 ![](<../../../../.gitbook/assets/image (237).png>)
 
 {% hint style="info" %}
-As soon as the fellow omnichannel agent is invited to an email inbox, they are all able to see all the old conversation that has happened before they arrival to that email inbox.
+As soon as the fellow Omnichannel agent is invited to an email inbox, they are all able to see all the old conversation that has happened before they arrival to that email inbox.
 {% endhint %}
 
 And you can conversate with them internally on the same channel.
@@ -72,6 +72,6 @@ To send an attachment:
 
 ![](<../../../../.gitbook/assets/image (243).png>)
 
-**It appears in the email of your omnichannel contact, as shown below:**
+**It appears in the email of your Omnichannel contact, as shown below:**
 
 ![](<../../../../.gitbook/assets/image (244).png>)

--- a/guides/app-guides/omnichannel-apps/facebook-app/README.md
+++ b/guides/app-guides/omnichannel-apps/facebook-app/README.md
@@ -7,7 +7,7 @@ description: Omnichannel Integration between Rocket.Chat and Facebook.
 Omnichannel Integration between Rocket.Chat and Facebook Messenger. With the Facebook Messenger app, you can handle messages from your Facebook contacts directly in Rocket.Chat. It works simply: your FB customers contact you via Messenger, you answer chats from Rocket.Chat. Some key features of this integration include sending messages with quick reply buttons, welcome messages(starting/closing chat), file sharing, and the correlation between your FB pages and your Rocket.Chat departments.
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="facebook-app-installation.md" %}

--- a/guides/app-guides/omnichannel-apps/facebook-app/facebook-app-agents-guide.md
+++ b/guides/app-guides/omnichannel-apps/facebook-app/facebook-app-agents-guide.md
@@ -4,7 +4,7 @@ If you have Facebook app integration in place and a user sends you a message on 
 
 ![](<../../../../.gitbook/assets/image (549).png>)
 
-it appears in your Rocket.Chat workspace, just like any other omnichannel conversation.
+it appears in your Rocket.Chat workspace, just like any other Omnichannel conversation.
 
 ![](<../../../../.gitbook/assets/image (551).png>)
 

--- a/guides/app-guides/omnichannel-apps/hubspot-crm/README.md
+++ b/guides/app-guides/omnichannel-apps/hubspot-crm/README.md
@@ -9,6 +9,6 @@ You can add HubSpot CRM to your Rocket.Chat account to manage the contacts and r
 #### Before you get started
 
 {% hint style="info" %}
-* You must have the [omnichannel feature](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) enabled and [agents](https://docs.rocket.chat/guides/omnichannel/agents) and [managers](https://docs.rocket.chat/guides/omnichannel/managers) assigned to receive and send omnichannel messages.
+* You must have the [Omnichannel feature](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) enabled and [agents](https://docs.rocket.chat/guides/omnichannel/agents) and [managers](https://docs.rocket.chat/guides/omnichannel/managers) assigned to receive and send Omnichannel messages.
 * **Migrate an API key integration to a private app**: If you've built a Rocket.Chat and HubSpot CRM integration that uses a [HubSpot API key](https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key), you need to complete the migration over to your private app, remove all references to the HubSpot API key from your code, and use the approach to use your private app's access token.&#x20;
 {% endhint %}

--- a/guides/app-guides/omnichannel-apps/instagram-direct/README.md
+++ b/guides/app-guides/omnichannel-apps/instagram-direct/README.md
@@ -15,7 +15,7 @@ The Integration is available to the following Instagram Direct Professional Acco
 Please find more info on the official rollout page by Instagram Direct [here](https://developers.facebook.com/docs/messenger-platform/instagram/rollout/).
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="instagram-Direct-installation.md" %}

--- a/guides/app-guides/omnichannel-apps/instagram-direct/instagram-direct-agents-guide.md
+++ b/guides/app-guides/omnichannel-apps/instagram-direct/instagram-direct-agents-guide.md
@@ -4,7 +4,7 @@ If you have Instagram Direct integration in place and a user sends you a message
 
 ![](<../../../../.gitbook/assets/2021-12-31\_20-27-38 (1).png>)
 
-it appears in your Rocket.Chat workspace, just like any other omnichannel conversation.
+it appears in your Rocket.Chat workspace, just like any other Omnichannel conversation.
 
 ![](../../../../.gitbook/assets/2021-12-31\_20-30-41.png)
 

--- a/guides/app-guides/omnichannel-apps/rasa-app/README.md
+++ b/guides/app-guides/omnichannel-apps/rasa-app/README.md
@@ -6,10 +6,10 @@ description: >-
 
 # Rasa App
 
-Using Rocket.Chat and the Rasa Chatbot platform integration, you can set up and train your chatbot to respond to any query it's been trained for and configure it to act as an omnichannel agent.
+Using Rocket.Chat and the Rasa Chatbot platform integration, you can set up and train your chatbot to respond to any query it's been trained for and configure it to act as an Omnichannel agent.
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="rasa-app-installation.md" %}

--- a/guides/app-guides/omnichannel-apps/salesforce-crm-integration/README.md
+++ b/guides/app-guides/omnichannel-apps/salesforce-crm-integration/README.md
@@ -5,7 +5,7 @@ description: Integration between Rocket.Chat and Salesforce CRM platform.
 # Salesforce CRM Integration
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="salesforce-crm-installation.md" %}

--- a/guides/app-guides/omnichannel-apps/salesforce-crm-integration/salesforce-crm-agents-guide.md
+++ b/guides/app-guides/omnichannel-apps/salesforce-crm-integration/salesforce-crm-agents-guide.md
@@ -4,7 +4,7 @@ If you have Salesforce CRM integration in place and a user sends you a message,
 
 ![](<../../../../.gitbook/assets/image (474).png>)
 
-It appears in your Rocket.Chat workspace just like any other omnichannel conversation, as shown below:
+It appears in your Rocket.Chat workspace just like any other Omnichannel conversation, as shown below:
 
 ![](<../../../../.gitbook/assets/image (475).png>)
 

--- a/guides/app-guides/omnichannel-apps/sms.md
+++ b/guides/app-guides/omnichannel-apps/sms.md
@@ -35,7 +35,7 @@ With the configuration complete, you can go ahead and **Try sending an SMS** to 
 
 ## Twilio SMS and Rocket.Chat Webhook
 
-After configuring your Twilio number for messaging, the next step is to link it to Rocket.Chat through an omnichannel webhook [endpoint](https://developer.rocket.chat/reference/api/rest-api/endpoints/omnichannel/omnichannel-endpoints/sms-incoming-twilio).
+After configuring your Twilio number for messaging, the next step is to link it to Rocket.Chat through an Omnichannel webhook [endpoint](https://developer.rocket.chat/reference/api/rest-api/endpoints/omnichannel/omnichannel-endpoints/sms-incoming-twilio).
 
 * From your [Twilio console](https://console.twilio.com/), navigate to **Phone Numbers** > **Manage** > **Active numbers.** You will see your Twilio provisioned number and the messaging service it is linked to
 * Click on the number to open its configuration page

--- a/guides/app-guides/omnichannel-apps/telegram-app/README.md
+++ b/guides/app-guides/omnichannel-apps/telegram-app/README.md
@@ -5,7 +5,7 @@ description: Omnichannel Integration between Rocket.Chat and Telegram.
 # Telegram App
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="telegram-app-installation.md" %}

--- a/guides/app-guides/omnichannel-apps/telegram-app/telegram-app-agents-guide.md
+++ b/guides/app-guides/omnichannel-apps/telegram-app/telegram-app-agents-guide.md
@@ -4,7 +4,7 @@ If you have Telegram app integration in place and a user sends you a message on 
 
 ![](../../../../.gitbook/assets/img\_3509.png)
 
-it appears in your Rocket.Chat workspace just like any other omnichannel conversation.
+it appears in your Rocket.Chat workspace just like any other Omnichannel conversation.
 
 ![](<../../../../.gitbook/assets/image (572).png>)
 

--- a/guides/app-guides/omnichannel-apps/telegram-app/telegram-app-configuration/README.md
+++ b/guides/app-guides/omnichannel-apps/telegram-app/telegram-app-configuration/README.md
@@ -47,6 +47,6 @@ You can also use quick reply buttons to send/receive quick replies on telegram.
 **If you don't yet have a chatbot solution ready to connect to Omnichannel or are interested in discovering** [**Rocket.Chat**](http://rocket.chat) **natively compatible solutions such as** [**Dialogflow**](https://docs.rocket.chat/guides/app-guides/omnichannel-apps/dialogflow-app) **or** [**RASA**](https://docs.rocket.chat/guides/app-guides/omnichannel-apps/rasa-app)**. Check out our** [**marketplace**](https://rocket.chat/marketplace) **and learn more!**
 {% endhint %}
 
-You can also have [**Assign new conversations to bot agent**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#routing) \*\*\*\* toggled on for the routing conversation to the bot agent if any. Please note that it’s an optional configuration, but for companies that have a chatbot user serving omnichannel conversations that’s a required setting.
+You can also have [**Assign new conversations to bot agent**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#routing) \*\*\*\* toggled on for the routing conversation to the bot agent if any. Please note that it’s an optional configuration, but for companies that have a chatbot user serving Omnichannel conversations that’s a required setting.
 
 ![Telegram routing to bot agent](<../../../../../.gitbook/assets/bot agent .png>)

--- a/guides/app-guides/omnichannel-apps/twitter-app/README.md
+++ b/guides/app-guides/omnichannel-apps/twitter-app/README.md
@@ -5,7 +5,7 @@ description: Omnichannel Integration between Rocket.Chat and Twitter.
 # Twitter App
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](https://docs.rocket.chat/guides/administration/settings/omnichannel-admins-guide#enable-omnichannel) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% hint style="info" %}

--- a/guides/app-guides/omnichannel-apps/twitter-app/twitter-app-agents-guide.md
+++ b/guides/app-guides/omnichannel-apps/twitter-app/twitter-app-agents-guide.md
@@ -4,7 +4,7 @@ If you have Twitter app integration in place and a user sends you a message on y
 
 ![](../../../../.gitbook/assets/1621376643503.jpg)
 
-it appears in your Rocket.Chat workspace just like any other omnichannel conversation.
+it appears in your Rocket.Chat workspace just like any other Omnichannel conversation.
 
 ![](../../../../.gitbook/assets/image%20%28422%29.png)
 

--- a/guides/app-guides/omnichannel-apps/whatsapp-sandbox/README.md
+++ b/guides/app-guides/omnichannel-apps/whatsapp-sandbox/README.md
@@ -11,7 +11,7 @@ This app is not intended for production use. It is only intended for testing pur
 {% endhint %}
 
 {% hint style="warning" %}
-You must have the [omnichannel feature](../../../administration/admin-panel/settings/omnichannel-admins-guide/) enabled, as well as have [agents](https://docs.rocket.chat/guides/omnichannel/agents) and [managers](https://docs.rocket.chat/guides/omnichannel/managers) assigned in order to receive and send omnichannel messages**.**
+You must have the [Omnichannel feature](../../../administration/admin-panel/settings/omnichannel-admins-guide/) enabled, as well as have [agents](https://docs.rocket.chat/guides/omnichannel/agents) and [managers](https://docs.rocket.chat/guides/omnichannel/managers) assigned in order to receive and send Omnichannel messages**.**
 {% endhint %}
 
 ### Quickstart:  How to test WhatsApp in the Sandbox <a href="#quickstart-set-up-a-log-analytics-workspace" id="quickstart-set-up-a-log-analytics-workspace"></a>

--- a/guides/app-guides/omnichannel-apps/whatsapp-sandbox/whatsapp-sandbox-agents-guide.md
+++ b/guides/app-guides/omnichannel-apps/whatsapp-sandbox/whatsapp-sandbox-agents-guide.md
@@ -2,7 +2,7 @@
 
 ### To send messages
 
-If you have WhatsApp Sandbox integration in place and a user sends you a message using their 360dialog Sandbox account, it appears in your Rocket.Chat workspace just like any other omnichannel conversation, as shown below:
+If you have WhatsApp Sandbox integration in place and a user sends you a message using their 360dialog Sandbox account, it appears in your Rocket.Chat workspace just like any other Omnichannel conversation, as shown below:
 
 Click **Take It!** to serve this conversation.&#x20;
 

--- a/guides/app-guides/omnichannel-apps/whatsapp/README.md
+++ b/guides/app-guides/omnichannel-apps/whatsapp/README.md
@@ -9,7 +9,7 @@ It is a paid subscription and costs you $39 per month.
 ![](<../../../../.gitbook/assets/image (641) (1) (1) (1) (1) (1).png>)
 
 {% hint style="warning" %}
-**You must have the** [**omnichannel feature**](../../../administration/admin-panel/settings/omnichannel-admins-guide/) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send omnichannel messages.**
+**You must have the** [**Omnichannel feature**](../../../administration/admin-panel/settings/omnichannel-admins-guide/) **enabled as well as have** [**agents**](https://docs.rocket.chat/guides/omnichannel/agents) **and** [**managers**](https://docs.rocket.chat/guides/omnichannel/managers) **assigned in order to receive and send Omnichannel messages.**
 {% endhint %}
 
 {% content-ref url="whatsapp-installation.md" %}

--- a/guides/app-guides/omnichannel-apps/whatsapp/whatsapp-agents-guide.md
+++ b/guides/app-guides/omnichannel-apps/whatsapp/whatsapp-agents-guide.md
@@ -4,7 +4,7 @@ If you have WhatsApp integration in place and a user sends you a message using t
 
 ![](<../../../../.gitbook/assets/image (447).png>)
 
-it appears in your Rocket.Chat workspace just like any other omnichannel conversation, as shown below:
+it appears in your Rocket.Chat workspace just like any other Omnichannel conversation, as shown below:
 
 ![](<../../../../.gitbook/assets/image (452).png>)
 

--- a/guides/message-auditing/README.md
+++ b/guides/message-auditing/README.md
@@ -72,7 +72,7 @@ The conversation pop up, as shown below:
 
 ### By Omnichannel
 
-Similary you can also audit an omnichannel conversation.
+Similary you can also audit an Omnichannel conversation.
 
 To search for a specific omichannel conversation:
 

--- a/guides/omnichannel/README.md
+++ b/guides/omnichannel/README.md
@@ -13,7 +13,7 @@ The Rocket.Chat [Omnichannel](https://en.wikipedia.org/wiki/Omnichannel)capabili
   * [Email](../app-guides/omnichannel-apps/email-inboxes/)
 
 {% hint style="info" %}
-A very practical use case is using omnichannel to **acquire** and **retain** customers in a multi-channel environment in order to save valuable potential sales while building relationships, providing an exceptional experience and the possibility to communicate and engage with multiple communication mediums.
+A very practical use case is using Omnichannel to **acquire** and **retain** customers in a multi-channel environment in order to save valuable potential sales while building relationships, providing an exceptional experience and the possibility to communicate and engage with multiple communication mediums.
 {% endhint %}
 
 ## Omnichannel Activation
@@ -23,14 +23,14 @@ A very practical use case is using omnichannel to **acquire** and **retain** cus
 To enable the Omnichannel feature on your Rocket.Chat instance:
 
 1. Go to **Administration > Settings > Omnichannel**
-2. **Enable** omnichannel and hit **Save changes**
+2. **Enable** Omnichannel and hit **Save changes**
 
 Now the admin will have access to _**Omnichannel Panel Settings**_ through a new menu called `Omnichannel`, as shown below:
 
 ![Omnichannel panel settings](<../../.gitbook/assets/image (587).png>)
 
 {% hint style="info" %}
-[Find out how to configure omnichannel on your Rocket.Chat workspace.](../administration/admin-panel/settings/omnichannel-admins-guide/)
+[Find out how to configure Omnichannel on your Rocket.Chat workspace.](../administration/admin-panel/settings/omnichannel-admins-guide/)
 {% endhint %}
 
 Omnichannel area of Rocket.Chat has three primary users.
@@ -39,7 +39,7 @@ Omnichannel area of Rocket.Chat has three primary users.
 2. [Managers](https://docs.rocket.chat/guides/omnichannel-guides/omnichannel-manger-guides)
 3. [Agents](https://docs.rocket.chat/guides/omnichannel/agents)
 
-Being an [omnichannel manager](managers.md), you can access omnichannel settings by **Avatar Menu  > Omnichannel**
+Being an [Omnichannel manager](managers.md), you can access Omnichannel settings by **Avatar Menu  > Omnichannel**
 
 ![Omnichannel panel](<../../.gitbook/assets/image (58).png>)
 

--- a/guides/omnichannel/canned-responses/canned-responses-rocket.chat-admins-guides.md
+++ b/guides/omnichannel/canned-responses/canned-responses-rocket.chat-admins-guides.md
@@ -27,7 +27,7 @@ Under the **Administration** > **Permissions** section, you can define which use
 
 ![](<../../../.gitbook/assets/image (512).png>)
 
-Check the omnichannel manager's guide for canned responses to save a new canned response for your workspace.
+Check the Omnichannel manager's guide for canned responses to save a new canned response for your workspace.
 
 {% content-ref url="canned-responses-omnichannel-managers-guide/" %}
 [canned-responses-omnichannel-managers-guide](canned-responses-omnichannel-managers-guide/)

--- a/guides/omnichannel/departments.md
+++ b/guides/omnichannel/departments.md
@@ -28,7 +28,7 @@ To create a new Omnichannel department:&#x20;
 
 ![Live Chat widget select department](<../../.gitbook/assets/Live Chat widget select department>)
 
-5\. **Email**: Forward your omnichannel conversations to the email address of your choice, during the hours you are offline.
+5\. **Email**: Forward your Omnichannel conversations to the email address of your choice, during the hours you are offline.
 
 6\. **Show on offline page**: A radio button if you want your department to show offline during off business hours. If you enable it will appear in the widget, as shown below:
 

--- a/guides/omnichannel/managers.md
+++ b/guides/omnichannel/managers.md
@@ -1,6 +1,6 @@
 # Managers
 
-Omnichannel managers are responsible for managing omnichannel conversations, they can [monitor ](real-time-monitoring.md)and see [analytics](analytics.md) of omnichannel activities.
+Omnichannel managers are responsible for managing Omnichannel conversations, they can [monitor ](real-time-monitoring.md)and see [analytics](analytics.md) of Omnichannel activities.
 
 To access this menu, go to **Avatar Menu  > Omnichannel > Managers**. Here, you can **view**, **add** or **remove** managers.
 
@@ -12,8 +12,8 @@ On visiting the Omnichannel managers page, a list of all the existing managers i
 
 ## 2. Add a new Omnichannel manager
 
-To add a user as an Omnichannel manager, simply search or select the user from the **username field** and **Add**. This will automatically assign the `Live Chat Manager` role to that user and they can now [monitor ](real-time-monitoring.md)and see [analytics](analytics.md) of omnichannel activities.
+To add a user as an Omnichannel manager, simply search or select the user from the **username field** and **Add**. This will automatically assign the `Live Chat Manager` role to that user and they can now [monitor ](real-time-monitoring.md)and see [analytics](analytics.md) of Omnichannel activities.
 
 ## 3. Remove Omnichannel manager
 
-To remove or revoke Omnichannel manager access from a user, click the **delete icon** by the right of the user on the Omnichannel managers list. This will remove the `Live Chat Manager` role from that user and they won't be able to [monitor](real-time-monitoring.md), [view analytics](analytics.md) or even see the omnichannel menu.
+To remove or revoke Omnichannel manager access from a user, click the **delete icon** by the right of the user on the Omnichannel managers list. This will remove the `Live Chat Manager` role from that user and they won't be able to [monitor](real-time-monitoring.md), [view analytics](analytics.md) or even see the Omnichannel menu.

--- a/guides/omnichannel/omnichannel-agents-guides/README.md
+++ b/guides/omnichannel/omnichannel-agents-guides/README.md
@@ -1,6 +1,6 @@
 # Omnichannel Agent's Guides
 
-Being an omnichannel agent, you can log in to the server using your Id and password and land on the home screen, as shown below:
+Being an Omnichannel agent, you can log in to the server using your Id and password and land on the home screen, as shown below:
 
 ![](<../../../.gitbook/assets/image (202).png>)
 

--- a/guides/omnichannel/omnichannel-agents-guides/livechat-video-audio-call-agents-guide.md
+++ b/guides/omnichannel/omnichannel-agents-guides/livechat-video-audio-call-agents-guide.md
@@ -10,7 +10,7 @@ To enable Rocket.Chat video call feature, please contact your administrator or f
 The following flow is for web users but both (Web and Mobile) user journeys are supported.
 {% endhint %}
 
-**To initiate a call within an omnichannel conversation:**
+**To initiate a call within an Omnichannel conversation:**
 
 Click on the call button to initiate a call with the visitor.
 

--- a/guides/omnichannel/omnichannel-agents-guides/omnichannel-chat/omnichannel-chat-quick-actions.md
+++ b/guides/omnichannel/omnichannel-agents-guides/omnichannel-chat/omnichannel-chat-quick-actions.md
@@ -44,7 +44,7 @@ If you want to forward a chat to a particular agent (from any department) to ser
 
 ## Transcript
 
-The chat transcript will be sent to the omnichannel visitor as soon as the conversation ends, as shown below:
+The chat transcript will be sent to the Omnichannel visitor as soon as the conversation ends, as shown below:
 
 ![](<../../../../.gitbook/assets/image (313).png>)
 
@@ -60,7 +60,7 @@ When you are assisting chats, Omnichannel contacts can drop the conversation, bu
 
 ![](<../../../../.gitbook/assets/image (330).png>)
 
-If the omnichannel contact engages again, the routing algorithm will try to find you first to assign this conversation. In case you are busy serving other chats at maximum capacity, the chat will be assigned to the next available agent.&#x20;
+If the Omnichannel contact engages again, the routing algorithm will try to find you first to assign this conversation. In case you are busy serving other chats at maximum capacity, the chat will be assigned to the next available agent.&#x20;
 
 Or click **Resume** and engage with the same contact again at any time, as shown below:
 

--- a/guides/omnichannel/omnichannel-agents-guides/omnichannel-chats.md
+++ b/guides/omnichannel/omnichannel-agents-guides/omnichannel-chats.md
@@ -2,17 +2,17 @@
 
 ## Chats
 
-After you log in and wish to start taking omnichannel chats, you can make yourself **Available** as an omnichannel agent by clicking the **Chat** button, as shown below:
+After you log in and wish to start taking Omnichannel chats, you can make yourself **Available** as an Omnichannel agent by clicking the **Chat** button, as shown below:
 
 ![](<../../../.gitbook/assets/image (236) (1).png>)
 
-You can now see the omnichannel chats queue and are available to take the chats:
+You can now see the Omnichannel chats queue and are available to take the chats:
 
 ![](<../../../.gitbook/assets/image (223).png>)
 
 ## Queue
 
-Click the **Queue** button to see the current omnichannel chats queue:
+Click the **Queue** button to see the current Omnichannel chats queue:
 
 ![](<../../../.gitbook/assets/image (224).png>)
 
@@ -20,7 +20,7 @@ as shown below:
 
 ![](<../../../.gitbook/assets/image (226).png>)
 
-All the chats you are currently serving as an omnichannel agent appear in your queue:
+All the chats you are currently serving as an Omnichannel agent appear in your queue:
 
 {% hint style="info" %}
 As soon as you close them, they will disappear from the queue.

--- a/guides/omnichannel/omnichannel-agents-guides/omnichannel-contact-center.md
+++ b/guides/omnichannel/omnichannel-agents-guides/omnichannel-contact-center.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  The contact center serves as a directory for omnichannel agents and mangers to
+  The contact center serves as a directory for Omnichannel agents and mangers to
   access contacts/visitor's information and archived conversation (that they
   have served in the past) at any moment.
 ---
@@ -21,7 +21,7 @@ Once you click on the **Contact Center** button following screen appears:
 
 ## Contacts
 
-Under the **Contacts** tab, you can see all the contacts you have been serving as an omnichannel agent.
+Under the **Contacts** tab, you can see all the contacts you have been serving as an Omnichannel agent.
 
 ### Search a contact
 
@@ -58,7 +58,7 @@ Click **Edit** to edit contact details. You can edit any details you want here.&
 
 ## Calls
 
-You can see all the calls you have been serving as an omnichannel agent under **Calls** tab.
+You can see all the calls you have been serving as an Omnichannel agent under **Calls** tab.
 
 {% hint style="info" %}
 Please note that if you are a call center administrator, you can view all the calls that your agents have served.

--- a/guides/omnichannel/webhooks-managers-guide.md
+++ b/guides/omnichannel/webhooks-managers-guide.md
@@ -6,7 +6,7 @@ To access **Webhooks** settings, go to **Avatar Menu  > Omnichannel > Webhooks**
 
 ## Create Omnichannel Webhook
 
-To create a new omnichannel webhook, you need to provide the following details
+To create a new Omnichannel webhook, you need to provide the following details
 
 * **Webhook URL**: The Webhook URL from the system you want to connect
 * **Secret Token**: Enter the secret token

--- a/guides/rocket.chat-call-center/README.md
+++ b/guides/rocket.chat-call-center/README.md
@@ -2,9 +2,9 @@
 
 **Omnichannel** means fulfilling customers’ needs at every touchpoint and providing the same functionality and experience across channels, no matter how a customer chooses to interact. The Voice channel is the most important touch point because it is the human connection people crave. A standalone telephony solution creates data silos with disconnected insights of customer interactions and agent performance across channels.
 
-To fulfill this gap, and avoid fragmented experiences for agents and customers Rocket.Chat offers a voice channel feature set. It is a key part of our omnichannel contact center because we know your customers expect to be able to get through to your live agent on the phone when they need to. It helps you get the most out of your in-house or remote back office teams and deliver the experience that meets your customers' expectations.
+To fulfill this gap, and avoid fragmented experiences for agents and customers Rocket.Chat offers a voice channel feature set. It is a key part of our Omnichannel contact center because we know your customers expect to be able to get through to your live agent on the phone when they need to. It helps you get the most out of your in-house or remote back office teams and deliver the experience that meets your customers' expectations.
 
-In the following articles, we help you onboard and start using **Rocket.Chat's voice channel**, as an extension to our omnichannel feature set, with outstanding customer experience.&#x20;
+In the following articles, we help you onboard and start using **Rocket.Chat's voice channel**, as an extension to our Omnichannel feature set, with outstanding customer experience.&#x20;
 
 ****
 

--- a/guides/rocket.chat-conference-call/omnichannel-video-audio-call-admins-guide.md
+++ b/guides/rocket.chat-conference-call/omnichannel-video-audio-call-admins-guide.md
@@ -1,6 +1,6 @@
 # Omnichannel Video/Audio Call Configuration
 
-You can either use Jitsi or WebRTC as your omnichannel audio/video call provider.
+You can either use Jitsi or WebRTC as your Omnichannel audio/video call provider.
 
 {% hint style="info" %}
 If you want to check how to use it, refer to [agent's guide.](https://docs.rocket.chat/guides/omnichannel/omnichannel-agents-guides/livechat-video-audio-call-agents-guide)

--- a/guides/rocket.chat-voice-channel/README.md
+++ b/guides/rocket.chat-voice-channel/README.md
@@ -2,9 +2,9 @@
 
 **Omnichannel** means fulfilling customers’ needs at every touchpoint and providing the same functionality and experience across channels, no matter how a customer chooses to interact. The Voice channel is the most important touch point because it is the human connection people crave. A standalone telephony solution creates data silos with disconnected insights of customer interactions and agent performance across channels.
 
-To fulfill this gap, and avoid fragmented experiences for agents and customers Rocket.Chat offers a voice channel feature set. It is a key part of our omnichannel contact center because we know your customers expect to be able to get through to your live agent on the phone when they need to. It helps you get the most out of your in-house or remote back office teams and deliver the experience that meets your customers' expectations.
+To fulfill this gap, and avoid fragmented experiences for agents and customers Rocket.Chat offers a voice channel feature set. It is a key part of our Omnichannel contact center because we know your customers expect to be able to get through to your live agent on the phone when they need to. It helps you get the most out of your in-house or remote back office teams and deliver the experience that meets your customers' expectations.
 
-In the following articles, we help you onboard and start using **Rocket.Chat's voice channel**, as an extension to our omnichannel feature set, with outstanding customer experience.&#x20;
+In the following articles, we help you onboard and start using **Rocket.Chat's voice channel**, as an extension to our Omnichannel feature set, with outstanding customer experience.&#x20;
 
 ****
 

--- a/resources/frequently-asked-questions/whatsapp-business-app-faqs.md
+++ b/resources/frequently-asked-questions/whatsapp-business-app-faqs.md
@@ -234,7 +234,7 @@ You should do that through template messages as explained above.
 
 <summary>After the client replies to an active message, does he go to the agent who sent it?</summary>
 
-It depends on your current omnichannel setup as it can be redirected to a specific department or if it’s public. The message will go to the agent who sent it as long as the agent is active, if not it will be redirected to an active agent. See our documentation. [Link](https://developer.rocket.chat/reference/api/rest-api/endpoints/apps-endpoints/whatsapp-endpoints)
+It depends on your current Omnichannel setup as it can be redirected to a specific department or if it’s public. The message will go to the agent who sent it as long as the agent is active, if not it will be redirected to an active agent. See our documentation. [Link](https://developer.rocket.chat/reference/api/rest-api/endpoints/apps-endpoints/whatsapp-endpoints)
 
 </details>
 

--- a/rocket.chat-saas/cloud-account/cloud-account-setup-wizard.md
+++ b/rocket.chat-saas/cloud-account/cloud-account-setup-wizard.md
@@ -46,7 +46,7 @@ On the next screen, you can fill out the necessary information for your organiza
 Connecting your workplace to the cloud gives you access to interact with services like
 
 * Mobile push notifications gateway
-* Live Chat omnichannel proxy
+* Live Chat Omnichannel proxy
 * OAuth proxy for social network
 * Apps Marketplace
 {% endhint %}


### PR DESCRIPTION
A few occurrences still exists in links e.g `omnichannel/`, `omnichannel-` etc