### PR TITLE
Added a note/info for message permissions section

### DIFF
--- a/guides/user-guides/rooms/messaging/README.md
+++ b/guides/user-guides/rooms/messaging/README.md
@@ -2,6 +2,10 @@
 
 This page explains the ins and outs of messaging in Rocket.Chat.
 
+{% hint style="info" %}
+Make sure to go through [setting permissions for messages](https://docs.rocket.chat/guides/administration/admin-panel/settings/message) to be able to access all these features mentioned below!
+{% endhint %}
+
 ## Compose messages
 
 To compose a message in Rocket.Chat, go to the channel or user you want to send a message. Type message in the message box and press Enter or the **Send** Button.


### PR DESCRIPTION
## Issue in brief

While going through the documentation for using messages to explore the [Location](https://docs.rocket.chat/guides/user-guides/rooms/messaging#location) section, I wasn't able to find the respective **Share My Location** option in my Rocket.Chat application!

I then found out that I would first need to enable this option first via setting up Message Permissions from [this page](https://docs.rocket.chat/guides/administration/admin-panel/settings/message) 

## Suggested Fixes/Changes

So that no one else faces this issue, it would be helpful if we could add a note/info at the start of the document suggesting to go through the `Message Permissions` page before exploring this page to avoid further confusion.